### PR TITLE
UISEES-33: Replacing existing query search

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,8 +137,11 @@
     "@folio/stripes": "^6.0.0",
     "@folio/stripes-cli": "^1.20.0",
     "@folio/stripes-components": "^9.0.0",
+    "@folio/stripes-connect": "^6.0.0",
     "@folio/stripes-core": "^7.0.0",
+    "@folio/stripes-util": "^3.0.0",
     "@folio/stripes-smart-components": "^6.0.0",
+    "@storybook/react": "^5.3.19",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^11.0.2",
     "@testing-library/user-event": "^12.1.10",
@@ -161,10 +164,12 @@
     "react-intl": "^5.8.0",
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "^0.13.3",
-    "sinon": "^7.0.0"
+    "sinon": "^7.0.0",
+    "storybook-readme": "^5.0.8"
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
+    "classnames": "^2.2.6",
     "file-saver": "^2.0.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",

--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextArea from '@folio/stripes-components/lib/TextArea';
+
+const defaultStyle = {
+  height: '20px',
+  resize: 'none',
+};
+
+const propTypes = {
+  onChange: PropTypes.func,
+  searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  style: PropTypes.object,
+  value: PropTypes.string,
+};
+
+const ElasticQueryField = props => {
+  const {
+    onChange,
+    searchButtonRef = {},
+    style = defaultStyle,
+    value = '',
+  } = props;
+
+  const handleSearchTermsChange = event => {
+    onChange(event);
+  };
+
+  const handleKeyDown = event => {
+    switch (event.keyCode) {
+      case 13: // enter
+        event.preventDefault();
+        if (searchButtonRef.current) {
+          searchButtonRef.current.click();
+        }
+        break;
+      default:
+    }
+  };
+
+  return (
+    <TextArea
+      style={style}
+      marginBottom0
+      value={value}
+      onChange={handleSearchTermsChange}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+ElasticQueryField.propTypes = propTypes;
+
+export default ElasticQueryField;

--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -2,15 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TextArea from '@folio/stripes-components/lib/TextArea';
 
-const defaultStyle = {
-  height: '20px',
-  resize: 'none',
-};
-
 const propTypes = {
   onChange: PropTypes.func,
   searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  style: PropTypes.object,
   value: PropTypes.string,
 };
 
@@ -18,7 +12,6 @@ const ElasticQueryField = props => {
   const {
     onChange,
     searchButtonRef = {},
-    style = defaultStyle,
     value = '',
   } = props;
 
@@ -40,7 +33,6 @@ const ElasticQueryField = props => {
 
   return (
     <TextArea
-      style={style}
       marginBottom0
       value={value}
       onChange={handleSearchTermsChange}

--- a/src/components/ElasticQueryField/index.js
+++ b/src/components/ElasticQueryField/index.js
@@ -1,0 +1,1 @@
+export { default } from './ElasticQueryField';

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -22,7 +22,6 @@ import {
   IfPermission,
   CalloutContext,
 } from '@folio/stripes/core';
-import { SearchAndSortES } from '@folio/stripes/smart-components';
 import {
   Button,
   Icon,
@@ -54,6 +53,7 @@ import {
 import ErrorModal from '../ErrorModal';
 import CheckboxColumn from './CheckboxColumn';
 import SelectedRecordsModal from '../SelectedRecordsModal';
+import SearchAndSort from '../SearchAndSort';
 
 import { buildQuery } from '../../routes/buildManifestObject';
 
@@ -529,7 +529,7 @@ class InstancesList extends React.Component {
     return (
       <>
         <div data-test-inventory-instances>
-          <SearchAndSortES
+          <SearchAndSort
             actionMenu={this.getActionMenu}
             packageInfo={packageInfo}
             objectName="inventory"

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -22,7 +22,7 @@ import {
   IfPermission,
   CalloutContext,
 } from '@folio/stripes/core';
-import { SearchAndSort } from '@folio/stripes/smart-components';
+import { SearchAndSortES } from '@folio/stripes/smart-components';
 import {
   Button,
   Icon,
@@ -495,7 +495,18 @@ class InstancesList extends React.Component {
         </AppIcon>
       ),
       'relation': r => formatters.relationsFormatter(r, data.instanceRelationshipTypes),
-      'publishers': r => r?.publication?.map(p => (p ? `${p.publisher} ${p.dateOfPublication ? `(${p.dateOfPublication})` : ''}` : '')).join(', '),
+      'publishers': r => {
+        let publishers;
+
+        if (r?.publishers) {
+          publishers = r.publishers.map(p => {
+            return p
+              ? `${p.publisher} ${p.dateOfPublication ? `(${p.dateOfPublication})` : ''}`
+              : '';
+          });
+        }
+        return publishers?.join(', ');
+      },
       'publication date': r => r?.publication?.map(p => p.dateOfPublication).join(', '),
       'contributors': r => formatters.contributorsFormatter(r, data.contributorTypes),
     };
@@ -518,7 +529,7 @@ class InstancesList extends React.Component {
     return (
       <>
         <div data-test-inventory-instances>
-          <SearchAndSort
+          <SearchAndSortES
             actionMenu={this.getActionMenu}
             packageInfo={packageInfo}
             objectName="inventory"

--- a/src/components/SearchAndSort/ConnectedSource/ApolloConnectedSource.js
+++ b/src/components/SearchAndSort/ConnectedSource/ApolloConnectedSource.js
@@ -1,0 +1,99 @@
+export default class ApolloConnectedSource {
+  constructor(props, logger, resourceName) {
+    const name = resourceName || props.apolloResource;
+    if (!name) {
+      console.warn('ApolloConnectedSource: no resource-name specified'); // eslint-disable-line no-console
+    }
+
+    this.props = props;
+    this.data = props.parentData || {};
+    this.recordsObj = this.data[name] || {};
+    this.logger = logger;
+  }
+
+  records() {
+    const key = this.props.apolloRecordsKey;
+    const res = this.recordsObj[key] || [];
+    this.logger.log('source', 'records:', res);
+    return res;
+  }
+
+  // Number of records retrieved so far. This does not seem to be
+  // directly specified in the Apollo data, so we'll just count the
+  // actual records.
+  resultCount() {
+    const res = this.records().length;
+    this.logger.log('source', 'resultCount:', res);
+    return res;
+  }
+
+  // Number of records in the result-set, available to be retrieved
+  totalCount() {
+    const res = this.pending() ? null : this.recordsObj.totalRecords;
+    this.logger.log('source', 'totalCount:', res);
+    return res;
+  }
+
+  // False before and after a request, true only during
+  pending() {
+    let res = this.data.loading;
+    if (res === undefined) res = false;
+    this.logger.log('source', 'pending:', res);
+    return res;
+  }
+
+  // False before and during a request, true only after
+  loaded() {
+    const res = this.records() && !this.pending();
+    this.logger.log('source', 'loaded', res);
+    return res;
+  }
+
+  // I _think_ this is correct, but our server currently never supplies errors
+  failure() {
+    const res = this.data.error;
+    this.logger.log('source', 'failure', res);
+    return res;
+  }
+
+  failureMessage() {
+    // react-apollo failure object has: extraInfo, graphQLErrors, message, networkError, stack
+    const res = `GraphQL error: ${this.data.error.message.replace(/.*:\s*/, '')}`;
+    this.logger.log('source', 'failureMessage', res);
+    return res;
+  }
+
+  fetchMore(increment) {
+    const name = this.props.apolloResource;
+    const data = this.props.parentData;
+
+    data.fetchMore({
+      // We would like to specify `notifyOnNetworkStatusChange: true` here, but it has to be in the initial query
+      variables: {
+        cql: this.props.queryFunction(
+          this.props.parentResources.query,
+          this.props, this.props.parentResources,
+          this.logger
+        ),
+        offset: this.resultCount(),
+        limit: increment,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          ...prev,
+          ...{
+            [name]: { ...prev[name],
+              ...{ records: [...prev[name].records, ...fetchMoreResult[name].records] } },
+          }
+        };
+      },
+    });
+  }
+
+  successfulMutations() { // TODO once we have mutations happening via GraphQL
+    const res = this.recordsObj.successfulMutations || [];
+    this.logger.log('source', 'successfulMutations', res);
+    return res;
+  }
+}

--- a/src/components/SearchAndSort/ConnectedSource/ConnectedSource.js
+++ b/src/components/SearchAndSort/ConnectedSource/ConnectedSource.js
@@ -1,0 +1,26 @@
+// Simple classes that know how to answer certain questions about a
+// Stripes module's resources, and perform certain operations, based
+// on whether they were populated by stripes-connect or Apollo
+// GraphQL.
+//
+// Both classes need to provide the same methods with the same
+// signatures, as client code will not know or care which class it's
+// getting; but there's no way to express that requirement in ES6.
+
+import ApolloConnectedSource from './ApolloConnectedSource';
+import StripesConnectedSource from './StripesConnectedSource';
+
+// Factory creates the appropriate kind of ConnectedSource for the props we have
+function makeConnectedSource(props, logger, resourceName) {
+  if (props.parentData) {
+    return new ApolloConnectedSource(props, logger, resourceName);
+  } else if (props.parentResources) {
+    return new StripesConnectedSource(props, logger, resourceName);
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn('makeConnectedSource: no parentData or parentResources');
+    return null;
+  }
+}
+
+export default makeConnectedSource;

--- a/src/components/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/src/components/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -1,0 +1,88 @@
+const UNKNOWN_RECORDS_COUNT = 999999999;
+
+export default class StripesConnectedSource {
+  constructor(props, logger, resourceName = 'records') {
+    this.logger = logger;
+    this.update(props, resourceName);
+  }
+
+  update(props, resourceName = 'records') {
+    this.props = props;
+    this.resources = props.parentResources || props.resources || {};
+    this.recordsObj = this.resources[resourceName] || {};
+    this.mutator = props.parentMutator || props.mutator;
+  }
+
+  records() {
+    const res = this.recordsObj.records || [];
+    this.logger.log('source', 'records:', res);
+    return res;
+  }
+
+  resultCount() {
+    const res = this.resources.resultCount;
+    this.logger.log('source', 'resultCount:', res);
+    return res;
+  }
+
+  /**
+   * when there are > 10k results to a search, the `totalRecords`
+   * value comes back as `999999999`, so we use that value to indicate
+   * that the count is, in fact, undefined vs returning null to indicate
+   * that the count has not been calculated.
+   */
+  totalCount() {
+    let res;
+    if (!this.recordsObj.hasLoaded) {
+      res = null;
+    } else {
+      res = this.recordsObj.other.totalRecords !== UNKNOWN_RECORDS_COUNT ?
+        this.recordsObj.other.totalRecords : undefined;
+    }
+    this.logger.log('source', 'totalCount:', res);
+    return res;
+  }
+
+  pending() {
+    let res = this.recordsObj.isPending;
+    if (res === undefined) res = true;
+    this.logger.log('source', 'pending:', res);
+    return res;
+  }
+
+  loaded() {
+    const res = this.recordsObj.hasLoaded;
+    this.logger.log('source', 'loaded', res);
+    return res;
+  }
+
+  failure() {
+    const res = this.recordsObj.failed;
+    this.logger.log('source', 'failure', res);
+    return res;
+  }
+
+  failureMessage() {
+    const failed = this.recordsObj.failed;
+    // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors
+    const res = `Error ${failed.httpStatus}: ${failed.message.replace(/.*:\s*/, '')}`;
+    this.logger.log('source', 'failureMessage', res);
+    return res;
+  }
+
+  fetchMore(increment) {
+    this.mutator.resultCount.replace(this.resultCount() + increment);
+    // ... and stripes-connect notices this change and does the rest by magic
+  }
+
+  // fetch by offset which is passed in as index.
+  fetchOffset(index) {
+    this.mutator.resultOffset.replace(index);
+  }
+
+  successfulMutations() {
+    const res = this.recordsObj.successfulMutations || [];
+    this.logger.log('source', 'successfulMutations', res);
+    return res;
+  }
+}

--- a/src/components/SearchAndSort/ConnectedSource/index.js
+++ b/src/components/SearchAndSort/ConnectedSource/index.js
@@ -1,0 +1,1 @@
+export { default } from './ConnectedSource';

--- a/src/components/SearchAndSort/SearchAndSort.css
+++ b/src/components/SearchAndSort/SearchAndSort.css
@@ -1,0 +1,21 @@
+
+@import '@folio/stripes-components/lib/variables';
+
+/**
+ * SearchAndSort
+ */
+
+/* reset button wrap - minor alignment adjustment */
+.resetButtonWrap {
+  margin-left: -3px;
+}
+
+.searchField {
+  margin-bottom: calc(var(--control-margin-bottom) / 2);
+}
+
+.delimiter {
+  & > span:not(:last-child)::after {
+    content: "\00a0\B7\00a0";
+  }
+}

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -1,0 +1,1229 @@
+// A generalisation of the search-and-sort functionality that underlies searching-and-sorting modules
+
+// NOTE: modules using this with react-apollo MUST set errorPolicy: 'all' for Apollo.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Link,
+  Route,
+} from 'react-router-dom';
+import { withRouter } from 'react-router';
+import { FormattedMessage } from 'react-intl';
+import queryString from 'query-string';
+import {
+  includes,
+  debounce,
+  get,
+  upperFirst,
+  noop,
+  isEmpty,
+  defer,
+  omit,
+} from 'lodash';
+
+import FilterGroups, {
+  filterState,
+  handleFilterChange,
+  handleFilterClear
+} from '@folio/stripes-components/lib/FilterGroups';
+import {
+  Button,
+  Layer,
+  MultiColumnList,
+  Pane,
+  PaneMenu,
+  Paneset,
+  SRStatus,
+} from '@folio/stripes-components';
+import { withModule } from '@folio/stripes-core/src/components/Modules';
+import {
+  withStripes,
+  IfPermission,
+  AppIcon,
+  IntlConsumer,
+} from '@folio/stripes-core';
+import Tags from '@folio/stripes-smart-components/lib/Tags';
+import SearchField from '../SearchField';
+
+import {
+  mapNsKeys,
+  getNsKey,
+} from './nsQueryFunctions';
+import makeConnectedSource from './ConnectedSource';
+import { NoResultsMessage, ResetButton, CollapseFilterPaneButton, ExpandFilterPaneButton } from './components';
+
+import buildUrl from './buildUrl';
+
+import css from './SearchAndSort.css';
+
+const NO_PERMISSION_NODE = (
+  <div
+    style={{
+      position: 'absolute',
+      right: '1rem',
+      bottom: '1rem',
+      width: '34%',
+      zIndex: '9999',
+      padding: '1rem',
+      backgroundColor: '#fff',
+    }}
+  >
+    <h2><FormattedMessage id="stripes-smart-components.permissionError" /></h2>
+    <p><FormattedMessage id="stripes-smart-components.permissionsDoNotAllowAccess" /></p>
+  </div>
+);
+
+class SearchAndSort extends React.Component {
+  static propTypes = {
+    actionMenu: PropTypes.func, // parameter properties provided by caller
+    apolloQuery: PropTypes.object, // machine-readable
+    apolloResource: PropTypes.string,
+    basePath: PropTypes.string,
+    browseOnly: PropTypes.bool,
+    columnMapping: PropTypes.object,
+    columnWidths: PropTypes.object,
+    createRecordPath: PropTypes.string,
+    customPaneSub: PropTypes.node,
+    detailProps: PropTypes.object,
+    disableFilters: PropTypes.object,
+    disableRecordCreation: PropTypes.bool,
+    editRecordComponent: PropTypes.func,
+    filterChangeCallback: PropTypes.func,
+    filterConfig: PropTypes.arrayOf(
+      PropTypes.shape({
+        cql: PropTypes.string.isRequired,
+        label: PropTypes.node.isRequired,
+        name: PropTypes.string.isRequired,
+        values: PropTypes.arrayOf(
+          PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.shape({
+              cql: PropTypes.string.isRequired,
+              name: PropTypes.string.isRequired,
+            }),
+          ]),
+        ).isRequired,
+      }),
+    ),
+    finishedResourceName: PropTypes.string,
+    getCellClass: PropTypes.func,
+    getHelperComponent: PropTypes.func,
+    getHelperResourcePath: PropTypes.func,
+    hasNewButton: PropTypes.bool,
+    history: PropTypes.shape({ // provided by withRouter
+      push: PropTypes.func.isRequired,
+    }).isRequired,
+    initialFilters: PropTypes.string,
+    initialResultCount: PropTypes.number.isRequired,
+    location: PropTypes.shape({ // provided by withRouter
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string.isRequired,
+    }).isRequired,
+    massageNewRecord: PropTypes.func,
+    match: PropTypes.shape({ // provided by withRouter
+      path: PropTypes.string.isRequired,
+    }).isRequired,
+    maxSortKeys: PropTypes.number,
+    module: PropTypes.shape({ // values specified by the ModulesContext
+      displayName: PropTypes.node, // human-readable
+    }),
+    newRecordInitialValues: PropTypes.object,
+    newRecordPerms: PropTypes.string,
+    notLoadedMessage: PropTypes.element,
+    nsParams: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
+    objectName: PropTypes.string.isRequired,
+    onChangeIndex: PropTypes.func,
+    onCloseNewRecord: PropTypes.func,
+    onComponentWillUnmount: PropTypes.func,
+    onCreate: PropTypes.func,
+    onFilterChange: PropTypes.func,
+    onResetAll: PropTypes.func,
+    onSelectRow: PropTypes.func,
+    packageInfo: PropTypes.shape({ // values pulled from the provider's package.json config object
+      initialFilters: PropTypes.string, // default filters
+      moduleName: PropTypes.string, // machine-readable, for HTML ids and translation keys
+      name: PropTypes.string,
+      stripes: PropTypes.shape({
+        route: PropTypes.string, // base route; used to construct URLs
+        type: PropTypes.string,
+      }).isRequired,
+    }),
+    pageAmount: PropTypes.number,
+    pagingType: PropTypes.string,
+    parentData: PropTypes.object,
+    parentMutator: PropTypes.shape({
+      query: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
+        update: PropTypes.func.isRequired,
+      }),
+      resultCount: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
+      }).isRequired,
+      resultOffset: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
+      }),
+    }).isRequired, // only needed when GraphQL is used
+    parentResources: PropTypes.shape({
+      query: PropTypes.shape({
+        filters: PropTypes.string,
+        notes: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.bool,
+        ]),
+      }),
+      records: PropTypes.shape({
+        hasLoaded: PropTypes.bool.isRequired,
+        isPending: PropTypes.bool,
+        other: PropTypes.shape({
+          totalRecords: PropTypes.number.isRequired,
+        }),
+        successfulMutations: PropTypes.arrayOf(
+          PropTypes.shape({
+            record: PropTypes.shape({
+              id: PropTypes.string.isRequired,
+            }).isRequired,
+          }),
+        ),
+      }),
+      resultCount: PropTypes.number,
+    }).isRequired,
+    path: PropTypes.string,
+    queryFunction: PropTypes.func,
+    renderFilters: PropTypes.func,
+    renderNavigation: PropTypes.func,
+    resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
+    resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
+    resultsFormatter: PropTypes.shape({}),
+    searchableIndexes: PropTypes.arrayOf(PropTypes.object),
+    searchableIndexesPlaceholder: PropTypes.string,
+    selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
+    showSingleResult: PropTypes.bool,
+    sortableColumns: PropTypes.arrayOf(PropTypes.string),
+    stripes: PropTypes.shape({
+      connect: PropTypes.func,
+      hasPerm: PropTypes.func.isRequired,
+      logger: PropTypes.shape({
+        log: PropTypes.func,
+      }),
+    }).isRequired,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    viewRecordComponent: PropTypes.func,
+    viewRecordPathById: PropTypes.func,
+    viewRecordPerms: PropTypes.string.isRequired,
+    visibleColumns: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  static defaultProps = {
+    customPaneSub: null,
+    showSingleResult: false,
+    maxSortKeys: 2,
+    onComponentWillUnmount: noop,
+    onResetAll: noop,
+    filterChangeCallback: noop,
+    getHelperComponent: noop,
+    massageNewRecord: noop,
+    renderNavigation: noop,
+    selectedIndex: '',
+    hasNewButton: true,
+  };
+
+  constructor(props) {
+    super(props);
+
+    const {
+      viewRecordComponent,
+      stripes,
+    } = this.props;
+
+    this.state = {
+      selectedItem: this.initiallySelectedRecord,
+      filterPaneIsVisible: true,
+      locallyChangedSearchTerm: '',
+      locallyChangedQueryIndex: '',
+    };
+
+    this.handleFilterChange = handleFilterChange.bind(this);
+    this.handleFilterClear = handleFilterClear.bind(this);
+    if (viewRecordComponent) this.connectedViewRecord = stripes.connect(viewRecordComponent);
+
+    this.helperApps = {
+      tags: stripes.connect(Tags)
+    };
+
+    this.SRStatus = null;
+    this.lastNonNullReaultCount = undefined;
+    this.initialQuery = queryString.parse(this.initialSearch);
+    this.initialFilters = this.initialQuery.filters;
+    this.initialSort = this.initialQuery.sort;
+
+    const logger = stripes.logger;
+
+    this.log = logger.log.bind(logger);
+    this.searchButtonRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.updateLocallyChangedSearchTerm();
+  }
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const {
+      stripes: { logger },
+      finishedResourceName,
+    } = this.props;
+    const oldState = makeConnectedSource(this.props, logger);
+    const newState = makeConnectedSource(nextProps, logger);
+    const {
+      location: {
+        search,
+      },
+    } = nextProps;
+    const { qindex } = queryString.parse(search);
+
+    // If the nominated mutation has finished, select the newly created record
+    const oldStateForFinalSource = makeConnectedSource(this.props, logger, finishedResourceName);
+    const newStateForFinalSource = makeConnectedSource(nextProps, logger, finishedResourceName);
+
+    if (oldStateForFinalSource.records()) {
+      const finishedResourceNextSM = newStateForFinalSource.successfulMutations();
+
+      if (finishedResourceNextSM.length > oldStateForFinalSource.successfulMutations().length) {
+        const sm = newState.successfulMutations();
+
+        if (sm[0]) this.onSelectRow(undefined, { id: sm[0].record.id });
+      }
+    }
+
+    // If a search that was pending is now complete, notify the screen-reader
+    if (oldState.pending() && !newState.pending()) {
+      this.log('event', 'new search-result');
+      const count = newState.totalCount();
+
+      this.SRStatus.sendMessage(
+        <FormattedMessage id="stripes-smart-components.searchReturnedResults" values={{ count }} />
+      );
+    }
+
+    // if the results list is winnowed down to a single record, display the record.
+    if (nextProps.showSingleResult &&
+      newState.totalCount() === 1 &&
+      this.lastNonNullReaultCount > 1) {
+      this.onSelectRow(null, newState.records()[0]);
+    }
+
+    if (newState.totalCount() !== null) {
+      this.lastNonNullReaultCount = newState.totalCount();
+    }
+
+    // Reset local qindex if the qindex is not present in the url.
+    // This happens when the search segment changes.
+    if (this.state.locallyChangedQueryIndex && !qindex) {
+      this.setState({ locallyChangedQueryIndex: '' });
+    }
+  }
+
+  componentWillUnmount() {
+    const {
+      parentMutator: { query },
+      onComponentWillUnmount,
+    } = this.props;
+
+    if (this.isPluginMode()) {
+      query.replace(this.initialQuery);
+    }
+    onComponentWillUnmount(this.props);
+  }
+
+  isPluginMode() {
+    const {
+      packageInfo: {
+        stripes: {
+          type,
+        },
+      },
+    } = this.props;
+
+    return type === 'plugin';
+  }
+
+  updateLocallyChangedSearchTerm() {
+    const {
+      location: {
+        search,
+      },
+    } = this.props;
+    const resQuery = this.queryParam('query');
+    const { query } = queryString.parse(search);
+
+    // update locallyChangedSearchTerm only
+    // when query from resourceQuery matches url query
+    const term = (this.isPluginMode() || resQuery === query) ? query : '';
+
+    this.setState({ locallyChangedSearchTerm: term });
+  }
+
+  get initiallySelectedRecord() {
+    const { location: { pathname } } = this.props;
+
+    const match = pathname.match(/^\/.*\/view\/(.*)$/);
+    const recordId = match && match[1];
+
+    return { id: recordId };
+  }
+
+  get initialSearch() {
+    const { packageInfo: { stripes } } = this.props;
+    const initialPath = get(stripes, 'home') || get(stripes, 'route') || '';
+
+    return initialPath.indexOf('?') === -1
+      ? initialPath
+      : initialPath.substr(initialPath.indexOf('?') + 1);
+  }
+
+  craftLayerUrl = (mode) => {
+    const {
+      pathname,
+      search,
+    } = this.props.location;
+
+    const url = `${pathname}${search}`;
+
+    return `${url}${url.includes('?') ? '&' : '?'}layer=${mode}`;
+  };
+
+  onFilterChangeHandler = (filter) => {
+    const {
+      parentMutator: {
+        resultCount,
+        resultOffset,
+        query,
+      },
+      initialResultCount,
+      onFilterChange,
+    } = this.props;
+    const { locallyChangedSearchTerm } = this.state;
+
+    resultCount.replace(initialResultCount);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
+    query.update({ query: locallyChangedSearchTerm });
+
+    // use next tick in order to wait for the resource query to update
+    defer(() => onFilterChange(filter));
+  };
+
+  onChangeSearch = (e) => {
+    const query = e.target.value;
+
+    if (query) {
+      this.setState({ locallyChangedSearchTerm: query });
+    } else {
+      // defer to avoid delay on keyup when the last character is removed
+      defer(() => this.onClearSearchQuery());
+    }
+  };
+
+  onChangeIndex = (e) => {
+    this.setState({ locallyChangedQueryIndex: e.target.value });
+
+    if (this.props.onChangeIndex) {
+      this.props.onChangeIndex(e);
+    }
+  }
+
+  onSubmitSearch = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const {
+      locallyChangedSearchTerm,
+      locallyChangedQueryIndex,
+    } = this.state;
+
+    this.performSearch({
+      query: locallyChangedSearchTerm,
+      qindex: locallyChangedQueryIndex,
+    });
+  };
+
+  onChangeFilter = (e) => {
+    const {
+      parentMutator: { resultCount, resultOffset },
+      initialResultCount,
+      filterChangeCallback,
+    } = this.props;
+
+    resultCount.replace(initialResultCount);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
+    const newFilters = this.handleFilterChange(e);
+
+    filterChangeCallback(newFilters);
+  };
+
+  onClearFilter = (e) => {
+    const newFilters = this.handleFilterClear(e);
+
+    this.props.filterChangeCallback(newFilters);
+  };
+
+  resetLocallyChangedQuery = () => {
+    this.setState({
+      locallyChangedSearchTerm: '',
+      locallyChangedQueryIndex: '',
+    });
+  }
+
+  onClearSearch = () => {
+    this.log('action', 'cleared search');
+
+    this.resetLocallyChangedQuery();
+    this.transitionToParams({
+      query: '',
+      qindex: '',
+    });
+
+    // This allows the parent to reset other parameters like query index to
+    // something that it may prefer instead of an empty qindex.
+    this.props.filterChangeCallback({});
+  };
+
+  onClearSearchAndFilters = () => {
+    this.log('action', 'cleared search and filters');
+
+    this.resetLocallyChangedQuery();
+    this.transitionToParams({
+      filters: this.initialFilters || '',
+      sort: this.initialSort || '',
+      query: '',
+      qindex: '',
+    });
+
+    this.props.filterChangeCallback({});
+    this.props.onResetAll();
+  };
+
+  onClearSearchQuery = () => {
+    this.log('action', 'cleared search query');
+    this.setState({ locallyChangedSearchTerm: '' });
+    this.transitionToParams({ query: '' });
+  };
+
+  onCloseEdit = (e) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    this.log('action', 'clicked "close edit"');
+    this.transitionToParams({ layer: null });
+  };
+
+  onEdit = (e) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    this.log('action', 'clicked "edit"');
+    this.transitionToParams({ layer: 'edit' });
+  };
+
+  transitionToParams = values => {
+    const {
+      location,
+      history,
+      nsParams,
+      browseOnly,
+      basePath,
+      parentMutator: { query },
+    } = this.props;
+
+    const nsValues = mapNsKeys(values, nsParams);
+    const url = buildUrl(location, nsValues, basePath);
+
+    // react-router doesn't work well with our 'plugin' setup
+    // so unfortunately we still have to rely on query resource
+    // in those cases.
+    if (browseOnly) {
+      query.update(nsValues);
+    } else {
+      history.push(url);
+    }
+  };
+
+  onNeedMore = (askAmount, index) => {
+    const {
+      parentMutator: { resultOffset },
+      stripes: { logger },
+      resultCountIncrement,
+    } = this.props;
+    const source = makeConnectedSource(this.props, logger);
+
+    // If module provides offset mutator and index parameter, opt-in to fetch by offset.
+    if (resultOffset && index >= 0) {
+      source.fetchOffset(index);
+    } else {
+      source.fetchMore(resultCountIncrement);
+    }
+  };
+
+  onSelectRow = (e, meta) => {
+    const {
+      onSelectRow,
+      packageInfo,
+    } = this.props;
+
+    if (onSelectRow) {
+      const shouldFallBackToRegularRecordDisplay = onSelectRow(e, meta);
+
+      if (!shouldFallBackToRegularRecordDisplay) {
+        return;
+      }
+    }
+
+    this.log('action', `clicked ${meta.id}, selected record =`, meta);
+    this.setState({ selectedItem: meta });
+    this.transitionToParams({ _path: `${packageInfo.stripes.route}/view/${meta.id}` });
+  };
+
+  onSort = (e, meta) => {
+    const {
+      parentMutator: { resultCount, resultOffset },
+      initialResultCount,
+      maxSortKeys,
+      sortableColumns
+    } = this.props;
+
+    const newOrder = meta.name;
+
+    if (sortableColumns && !includes(sortableColumns, newOrder)) return;
+
+    const oldOrder = this.queryParam('sort');
+    const orders = oldOrder ? oldOrder.split(',') : [];
+    const mainSort = orders[0];
+    const isSameColumn = mainSort && newOrder === mainSort.replace(/^-/, '');
+
+    if (isSameColumn) {
+      orders[0] = `-${mainSort}`.replace(/^--/, '');
+    } else {
+      orders.unshift(newOrder);
+    }
+
+    const sortOrder = orders.slice(0, maxSortKeys).join(',');
+
+    this.log('action', `sorted by ${sortOrder}`);
+    // Reset result count when sorting so that only 1 page is initially retrieved
+    resultCount.replace(initialResultCount);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
+    this.transitionToParams({ sort: sortOrder });
+  };
+
+  getRowURL(id) {
+    const {
+      match: { path },
+      location: { search },
+    } = this.props;
+
+    return `${path}/view/${id}${search}`;
+  }
+
+  addNewRecord = (e) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    this.log('action', 'clicked "add new record"');
+    this.transitionToParams({ layer: 'create' });
+  };
+
+  // custom row formatter to wrap rows in anchor tags.
+  anchoredRowFormatter = (row) => {
+    const {
+      rowIndex,
+      rowClass,
+      rowData,
+      cells,
+      rowProps,
+      labelStrings
+    } = row;
+    const label = labelStrings && labelStrings.join('...');
+
+    return (
+      <div
+        role="row"
+        aria-rowindex={rowIndex + 2}
+        key={`row-${rowIndex}`}
+      >
+        { this.props.viewRecordPathById
+          ?
+            <Link
+              to={this.props.viewRecordPathById(rowData.id)}
+              data-label={label}
+              className={rowClass}
+              {...omit(rowProps, 'onClick')}
+            >
+              {cells}
+            </Link>
+          :
+            <a
+              href={this.getRowURL(rowData.id)}
+              data-label={label}
+              className={rowClass}
+              {...rowProps}
+            >
+              {cells}
+            </a>
+        }
+      </div>
+    );
+  };
+
+  closeNewRecord = (e) => {
+    this.log('action', 'clicked "close new record"');
+    if (this.props.onCloseNewRecord) {
+      this.props.onCloseNewRecord(e);
+    } else {
+      if (e) {
+        e.preventDefault();
+      }
+
+      this.transitionToParams({ layer: null });
+    }
+  };
+
+  collapseDetails = () => {
+    const { packageInfo: { stripes } } = this.props;
+
+    this.setState({ selectedItem: {} });
+    this.transitionToParams({ _path: `${stripes.route}/view` });
+  };
+
+  createRecord(record) {
+    const {
+      massageNewRecord,
+      onCreate,
+    } = this.props;
+
+    massageNewRecord(record);
+
+    return onCreate(record);
+  }
+
+  // eslint-disable-next-line react/sort-comp
+  performSearch = debounce((queryParams) => {
+    const {
+      parentMutator: { resultCount, resultOffset },
+      initialResultCount,
+    } = this.props;
+
+    this.log('action', `searched for '${queryParams.query}'`);
+    resultCount.replace(initialResultCount);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
+    this.transitionToParams(queryParams);
+  }, 350);
+
+  queryParam(name) {
+    const {
+      parentResources: { query },
+      nsParams,
+    } = this.props;
+    const nsKey = getNsKey(name, nsParams);
+
+    return get(query, nsKey);
+  }
+
+  toggleFilterPane = () => {
+    this.setState(prevState => ({ filterPaneIsVisible: !prevState.filterPaneIsVisible }));
+  };
+
+  toggleHelperApp = (curHelper) => {
+    const prevHelper = this.queryParam('helper');
+    const helper = prevHelper === curHelper ? null : curHelper;
+
+    this.transitionToParams({ helper });
+  };
+
+  toggleTags = () => this.toggleHelperApp('tags');
+
+  getModuleName() {
+    const { packageInfo: { name } } = this.props;
+
+    return name.replace(/.*\//, '');
+  }
+
+  isResetButtonDisabled() {
+    const initialFilters = this.initialFilters || '';
+    const currentFilters = this.queryParam('filters') || '';
+    const noFiltersChoosen = currentFilters === initialFilters;
+    const currentQuery = this.queryParam('query');
+    const searchTermFieldIsEmpty = isEmpty(this.state.locallyChangedSearchTerm || currentQuery);
+
+    return noFiltersChoosen && searchTermFieldIsEmpty;
+  }
+
+  renderResetButton = () => {
+    return (
+      <div className={css.resetButtonWrap}>
+        <ResetButton
+          id="clickable-reset-all"
+          label={<FormattedMessage id="stripes-smart-components.resetAll" />}
+          disabled={this.isResetButtonDisabled()}
+          onClick={this.onClearSearchAndFilters}
+        />
+      </div>
+    );
+  };
+
+  getHelperComponent(helperName) {
+    return this.props.getHelperComponent(helperName) ||
+      this.helperApps[helperName];
+  }
+
+  renderHelperApp() {
+    const {
+      stripes,
+      match,
+      getHelperResourcePath,
+    } = this.props;
+
+    const moduleName = this.getModuleName();
+    const helper = this.queryParam('helper');
+    const HelperAppComponent = this.getHelperComponent(helper);
+
+    if (!HelperAppComponent) {
+      return null;
+    }
+
+    return (
+      <Route
+        path={`${match.path}/view/:id`}
+        render={
+          props => {
+            const { match: { params } } = props;
+            const link = getHelperResourcePath
+              ? getHelperResourcePath(helper, params.id)
+              : `${moduleName}/${params.id}`;
+
+            return (
+              <HelperAppComponent
+                stripes={stripes}
+                link={link}
+                onToggle={() => this.toggleHelperApp(helper)}
+                {...props}
+              />
+            );
+          }
+        }
+      />
+    );
+  }
+
+  renderNewRecordBtn() {
+    const {
+      objectName,
+      disableRecordCreation,
+      newRecordPerms,
+      createRecordPath,
+    } = this.props;
+
+    if (disableRecordCreation || !newRecordPerms) {
+      return null;
+    }
+
+    return (
+      <IfPermission perm={newRecordPerms}>
+        <PaneMenu>
+          <FormattedMessage id="stripes-smart-components.addNew">
+            {ariaLabel => (
+              <Button
+                id={`clickable-new${objectName}`}
+                aria-label={ariaLabel}
+                buttonStyle="primary"
+                marginBottom0
+                href={createRecordPath ? undefined : this.craftLayerUrl('create')}
+                onClick={createRecordPath ? undefined : this.addNewRecord}
+                to={createRecordPath || undefined}
+              >
+                <FormattedMessage id="stripes-smart-components.new" />
+              </Button>
+            )}
+          </FormattedMessage>
+        </PaneMenu>
+      </IfPermission>
+    );
+  }
+
+  renderResultsFirstMenu() {
+    const { filterPaneIsVisible } = this.state;
+
+    // The toggle is hidden here and rendered within the search pane
+    // when the filter pane is visible
+    if (filterPaneIsVisible) {
+      return null;
+    }
+
+    const filters = filterState(this.queryParam('filters'));
+    const filterCount = Object.keys(filters).length;
+
+    return (
+      <PaneMenu>
+        <ExpandFilterPaneButton
+          filterCount={filterCount}
+          onClick={this.toggleFilterPane}
+        />
+      </PaneMenu>
+    );
+  }
+
+  renderRecordDetails(source) {
+    const {
+      browseOnly,
+      parentResources,
+      parentMutator,
+      stripes,
+      viewRecordPerms,
+      detailProps,
+      match,
+      path,
+    } = this.props;
+
+    if (browseOnly) {
+      return null;
+    }
+
+    if (stripes.hasPerm(viewRecordPerms)) {
+      return (
+        <Route
+          path={path || `${match.path}/view/:id`}
+          render={props => (
+            <this.connectedViewRecord
+              stripes={stripes}
+              paneWidth="44%"
+              parentResources={parentResources}
+              connectedSource={source}
+              parentMutator={parentMutator}
+              onClose={this.collapseDetails}
+              onEdit={this.onEdit}
+              editLink={this.craftLayerUrl('edit')}
+              onCloseEdit={this.onCloseEdit}
+              tagsToggle={this.toggleTags}
+              {...props}
+              {...detailProps}
+            />)}
+        />
+      );
+    }
+
+    return NO_PERMISSION_NODE;
+  }
+
+  renderCreateRecordLayer(source) {
+    const {
+      browseOnly,
+      parentResources,
+      editRecordComponent,
+      detailProps,
+      newRecordInitialValues,
+      parentMutator,
+      location,
+      stripes,
+      objectName,
+      disableRecordCreation,
+      newRecordPerms,
+    } = this.props;
+
+    if (browseOnly || !editRecordComponent) {
+      return null;
+    }
+
+    const urlQuery = queryString.parse(location.search || '');
+    const isOpen = urlQuery.layer ? urlQuery.layer === 'create' : false;
+    const EditRecordComponent = editRecordComponent;
+
+    if (!disableRecordCreation && stripes.hasPerm(newRecordPerms)) {
+      return (
+        <IntlConsumer>
+          {intl => (
+            <Layer
+              isOpen={isOpen}
+              contentLabel={intl.formatMessage({ id: 'stripes-smart-components.sas.createEntry' })}
+            >
+              <EditRecordComponent
+                stripes={stripes}
+                id={`${objectName}form-add${objectName}`}
+                initialValues={newRecordInitialValues}
+                connectedSource={source}
+                parentResources={parentResources}
+                parentMutator={parentMutator}
+                onSubmit={record => this.createRecord(record)}
+                onCancel={this.closeNewRecord}
+                {...detailProps}
+              />
+            </Layer>
+          )}
+        </IntlConsumer>
+      );
+    }
+
+    return null;
+  }
+
+  renderSearch(source) {
+    const {
+      objectName,
+      filterConfig,
+      renderFilters,
+      renderNavigation,
+      disableFilters,
+      searchableIndexes,
+      selectedIndex,
+    } = this.props;
+    const {
+      locallyChangedSearchTerm,
+      locallyChangedQueryIndex,
+    } = this.state;
+
+    const filters = filterState(this.queryParam('filters'));
+    const query = this.queryParam('query') || '';
+    const searchTerm = (locallyChangedSearchTerm !== undefined)
+      ? locallyChangedSearchTerm
+      : query;
+    const queryIndex = locallyChangedQueryIndex || selectedIndex;
+
+    return (
+      <form onSubmit={this.onSubmitSearch}>
+        {renderNavigation()}
+        <FormattedMessage
+          id="stripes-smart-components.searchFieldLabel"
+          values={{ moduleName: module ? module.displayName : '' }}
+        >
+          {ariaLabel => (
+            <SearchField
+              id={`input-${objectName}-search`}
+              isAdvancedSearch={queryIndex === 'advancedSearch'}
+              autoFocus
+              ariaLabel={ariaLabel}
+              className={css.searchField}
+              searchableIndexes={searchableIndexes}
+              searchButtonRef={this.searchButtonRef}
+              selectedIndex={queryIndex}
+              value={searchTerm}
+              loading={source.pending()}
+              marginBottom0
+              onChangeIndex={this.onChangeIndex}
+              onChange={this.onChangeSearch}
+              onClear={this.onClearSearchQuery}
+            />
+          )}
+        </FormattedMessage>
+        <Button
+          type="submit"
+          buttonStyle="primary"
+          fullWidth
+          disabled={!searchTerm}
+          data-test-search-and-sort-submit
+          ref={this.searchButtonRef}
+        >
+          <FormattedMessage id="stripes-smart-components.search" />
+        </Button>
+        {this.renderResetButton()}
+        {
+          renderFilters
+            ? renderFilters(this.onFilterChangeHandler)
+            : (
+              <FilterGroups
+                config={filterConfig}
+                filters={filters}
+                disableNames={disableFilters}
+                onChangeFilter={this.onChangeFilter}
+                onClearFilter={this.onClearFilter}
+              />
+            )
+        }
+      </form>
+    );
+  }
+
+  renderResultsList(source) {
+    const {
+      columnMapping,
+      columnWidths,
+      resultsFormatter,
+      visibleColumns,
+      objectName,
+      notLoadedMessage,
+      viewRecordPathById,
+      pageAmount,
+      pagingType,
+      getCellClass,
+    } = this.props;
+    const {
+      filterPaneIsVisible,
+      selectedItem,
+    } = this.state;
+
+    const objectNameUC = upperFirst(objectName);
+    const moduleName = this.getModuleName();
+    const records = source.records();
+    const count = source.totalCount();
+    const query = this.queryParam('query') || '';
+    const sortOrder = this.queryParam('sort') || '';
+    const message = <NoResultsMessage
+      source={source}
+      searchTerm={query}
+      filterPaneIsVisible={filterPaneIsVisible}
+      toggleFilterPane={this.toggleFilterPane}
+      notLoadedMessage={notLoadedMessage}
+    />;
+
+    return (
+      <FormattedMessage
+        id="stripes-smart-components.searchResults"
+        values={{ objectName: objectNameUC }}
+      >
+        {ariaLabel => (
+          <MultiColumnList
+            id={`list-${moduleName}`}
+            ariaLabel={ariaLabel}
+            totalCount={count}
+            contentData={records}
+            selectedRow={selectedItem}
+            formatter={resultsFormatter}
+            visibleColumns={visibleColumns}
+            sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
+            sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
+            isEmptyMessage={message}
+            columnWidths={columnWidths}
+            columnMapping={columnMapping}
+            loading={source.pending()}
+            autosize
+            virtualize
+            hasMargin
+            rowFormatter={this.anchoredRowFormatter}
+            containerRef={(ref) => { this.resultsList = ref; }}
+            onRowClick={viewRecordPathById ? undefined : this.onSelectRow}
+            onHeaderClick={this.onSort}
+            onNeedMoreData={this.onNeedMore}
+            pageAmount={pageAmount}
+            pagingType={pagingType}
+            getCellClass={getCellClass}
+          />
+        )}
+      </FormattedMessage>
+    );
+  }
+
+  getPaneSub(source) {
+    const {
+      customPaneSub,
+      resultCountMessageKey,
+    } = this.props;
+
+    const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
+    const isSourceLoaded = source.loaded();
+    const isTotalCountUndefined = source.totalCount() === undefined;
+    const isSearchResultCountUnknown = isSourceLoaded && isTotalCountUndefined;
+    const isSearchResultCountPresent = isSourceLoaded && !isTotalCountUndefined;
+
+    return (
+      <div className={css.delimiter}>
+        <span>
+          {isSearchResultCountUnknown && (
+            <FormattedMessage id="stripes-smart-components.searchResultsCountUnknown" />
+          )}
+          {isSearchResultCountPresent && (
+            <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />
+          )}
+          {!isSourceLoaded && (
+            <FormattedMessage id="stripes-smart-components.searchCriteria" />
+          )}
+        </span>
+        {customPaneSub && (
+          <span data-test-custom-pane-sub>{customPaneSub}</span>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      stripes,
+      actionMenu,
+      module,
+      title,
+      hasNewButton,
+    } = this.props;
+    const { filterPaneIsVisible } = this.state;
+
+    const source = makeConnectedSource(this.props, stripes.logger);
+    const moduleName = this.getModuleName();
+
+    return (
+      <Paneset data-test-search-and-sort>
+        <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
+
+        {/* Filter Pane */}
+        {filterPaneIsVisible &&
+          <Pane
+            data-test-filter-pane
+            id="pane-filter"
+            defaultWidth="320px"
+            paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
+            onClose={this.toggleFilterPane}
+            lastMenu={
+              <PaneMenu>
+                <CollapseFilterPaneButton
+                  onClick={this.toggleFilterPane}
+                />
+              </PaneMenu>
+            }
+          >
+            {this.renderSearch(source)}
+          </Pane>
+        }
+
+        {/* Results Pane */}
+        <Pane
+          id="pane-results"
+          padContent={false}
+          defaultWidth="fill"
+          actionMenu={actionMenu}
+          appIcon={<AppIcon app={moduleName} />}
+          paneTitle={title || (module && module.displayName)}
+          paneSub={this.getPaneSub(source)}
+          lastMenu={hasNewButton ? this.renderNewRecordBtn() : null}
+          firstMenu={this.renderResultsFirstMenu()}
+          noOverflow
+        >
+          {this.renderResultsList(source)}
+        </Pane>
+        {!this.props.viewRecordPathById && this.renderRecordDetails(source)}
+        {!this.props.createRecordPath && this.renderCreateRecordLayer(source)}
+        {this.renderHelperApp()}
+      </Paneset>
+    );
+  }
+}
+
+export default withRouter(
+  withModule(
+    props => props.packageInfo && props.packageInfo.name
+  )(withStripes(SearchAndSort))
+);

--- a/src/components/SearchAndSort/SearchAndSortQuery.js
+++ b/src/components/SearchAndSort/SearchAndSortQuery.js
@@ -1,0 +1,654 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import includes from 'lodash/includes';
+import noop from 'lodash/noop';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import debounce from 'lodash/debounce';
+import cloneDeep from 'lodash/cloneDeep';
+import queryString from 'query-string';
+import { withRouter } from 'react-router';
+
+import {
+  mapNsKeys,
+  getNsKey,
+} from './nsQueryFunctions';
+
+import buildUrl from './buildUrl';
+
+const locationQuerySetter = ({ location, history, nsValues }) => {
+  const url = buildUrl(location, nsValues);
+  history.push(url);
+};
+
+const locationQueryGetter = ({ location }) => {
+  return queryString.parse(location.search || '');
+};
+
+const defaultStateReducer = (state, nextState) => nextState;
+
+// output is ?filters=name.value,name.value,name.value
+const buildFilterString = (activeFilters) => {
+  const newFiltersString = Object.keys(activeFilters)
+    .filter((filterName) => Array.isArray(activeFilters[filterName]) && activeFilters[filterName].length)
+    .map((filterName) => {
+      return activeFilters[filterName].map((filterValue) => {
+        return `${filterName}.${filterValue}`;
+      }).join(',');
+    }).join(',');
+
+  return newFiltersString;
+};
+
+const buildFilterParams = (activeFilters) => {
+  const filterString = buildFilterString(activeFilters);
+  return { filters: filterString };
+};
+
+const filterStringToObject = (str) => {
+  const filterObject = {};
+  const filterArray = str.split(',');
+  filterArray.forEach(f => {
+    const [filterName, ...rest] = f.split('.');
+    const filterValue = rest.join('.'); // support both filterName.value and filterName.value.with.dot
+
+    if (filterObject[filterName]) {
+      filterObject[filterName].push(filterValue);
+    } else {
+      filterObject[filterName] = [filterValue];
+    }
+  });
+  return filterObject;
+};
+
+const translateKeys = (targetObject, refObject) => {
+  let res = {};
+  for (const p in refObject) {
+    if (Object.prototype.hasOwnProperty.call(targetObject, p)) {
+      res = Object.assign(res, refObject[p](targetObject[p]));
+    }
+  }
+  return res;
+};
+
+const getQueryStateSlice = (toParse, mapping, def = {}) => {
+  const source = queryString.parse(toParse);
+  const parsed = translateKeys(source, mapping);
+  const state = { ...def, ...parsed };
+  return state;
+};
+
+class SearchAndSortQuery extends React.Component {
+  static propTypes = {
+    children: PropTypes.func,
+    filterChangeCallback: PropTypes.func,
+    filterParamsMapping: PropTypes.object,
+    filtersToParams: PropTypes.func,
+    filtersToString: PropTypes.func,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
+    initialFilterState: PropTypes.object,
+    initialSearch: PropTypes.string,
+    initialSearchState: PropTypes.object,
+    initialSortState: PropTypes.object,
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string.isRequired,
+    }).isRequired,
+    maxSortKeys: PropTypes.number,
+    nsParams: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
+    onComponentWillUnmount: PropTypes.func,
+    queryGetter: PropTypes.func,
+    querySetter: PropTypes.func,
+    queryStateReducer: PropTypes.func,
+    searchChangeCallback: PropTypes.func,
+    searchParamsMapping: PropTypes.object,
+    sortableColumns: PropTypes.arrayOf(PropTypes.string),
+    sortChangeCallback: PropTypes.func,
+    sortParamsMapping: PropTypes.object,
+    syncToLocationSearch: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    maxSortKeys: 2,
+    filterChangeCallback: noop,
+    filtersToString: buildFilterString,
+    filtersToParams: buildFilterParams,
+    querySetter: locationQuerySetter,
+    queryGetter: locationQueryGetter,
+    queryStateReducer: defaultStateReducer,
+    searchChangeCallback: noop,
+    sortChangeCallback: noop,
+    searchParamsMapping: { 'query': v => ({ query : v }) },
+    filterParamsMapping: { 'filters': filterStringToObject },
+    sortParamsMapping: { 'sort': v => ({ sort: v }) },
+    syncToLocationSearch: true,
+  }
+
+  constructor(props) {
+    super(props);
+    this.queryParam = this.queryParam.bind(this);
+
+    // syncToLocationSearch - component will preferably init query state to the window location.
+    if (props.syncToLocationSearch) {
+      this.initialQuery = props.location.search || '';
+    } else {
+      this.initialQuery = props.initialSearch || '';
+    }
+
+    const defaultQueryState = {
+      searchFields: props.initialSearchState || getQueryStateSlice(props.initialSearch, props.searchParamsMapping),
+      filterFields: props.initialFilterState || getQueryStateSlice(props.initialSearch, props.filterParamsMapping),
+      sortFields: props.initialSortState || getQueryStateSlice(props.initialSearch, props.sortParamsMapping),
+    };
+
+    const initialQueryState = {
+      /* searchFields will be collected when the user clicks the "Search" button
+      *  filterFields are collected on filter change. The conventional shape is { query: <string> }
+      */
+      searchFields:  getQueryStateSlice(this.initialQuery, props.searchParamsMapping, props.initialSearchState),
+      /* filterFields will be applied onChange of any presentational filter control.
+      *  The conventional shape is { groupname: [filtername] ... }
+      */
+      filterFields: getQueryStateSlice(this.initialQuery, props.filterParamsMapping, props.initialFilterState),
+      /* sortFields are similar to filterFields. will be applied onChange of any presentational filter control.
+      *  The conventional shape is { sort: <string> }
+      */
+      sortFields:  getQueryStateSlice(this.initialQuery, props.sortParamsMapping, props.initialSortState),
+    };
+
+    // 'reset' functionality can be preserved even if initializing based on a
+    // link from the outside/pasted url on the address bar.
+    const searchChanged = !isEqual(
+      initialQueryState.searchFields,
+      defaultQueryState.searchFields,
+    );
+
+    const filterChanged = !isEqual(
+      initialQueryState.filterFields,
+      defaultQueryState.filterFields,
+    );
+
+    const sortChanged = !isEqual(
+      initialQueryState.sortFields,
+      defaultQueryState.sortFields,
+    );
+
+    this.state = {
+      ...initialQueryState,
+      previousQuery: props.location.search,
+      default: defaultQueryState,
+      changeType: 'init.reset',
+      searchChanged,
+      filterChanged,
+      sortChanged,
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    // reset query state if the window location changes to match the initial search...
+    // for instance, a user clicks the 'home' link of an app.
+    if (props.syncToLocationSearch) {
+      let nextState = {};
+      // capture previous query...
+      if (props.location.search !== state.previousQuery) {
+        nextState.previousQuery = props.location.search;
+
+        const queryStateFromLocation = {
+          searchFields:  getQueryStateSlice(props.location.search, props.searchParamsMapping, props.initialSearchState),
+          filterFields: getQueryStateSlice(props.location.search, props.filterParamsMapping, props.initialFilterState),
+          sortFields:  getQueryStateSlice(props.location.search, props.sortParamsMapping, props.initialSortState),
+        };
+
+        if (props.location.search === props.initialSearch &&
+          props.location.search !== state.previousQuery
+        ) {
+          const defaultState = {
+            ...queryStateFromLocation,
+            changeType: 'init',
+            searchChanged: false,
+            filterChanged: false,
+            sortChanged: false,
+          };
+          nextState = Object.assign(nextState, defaultState);
+        }
+        return nextState;
+      }
+    }
+
+    return null;
+  }
+
+  componentDidMount() {
+    if (this.props.syncToLocationSearch && Object.keys(this.state.searchFields).length > 0) {
+      this.onSubmitAll(false);
+    }
+  }
+
+  componentWillUnmount() {
+    const {
+      onComponentWillUnmount,
+      syncToLocationSearch,
+    } = this.props;
+
+    // in modules using local resource query, we need to reset the query on unmount.
+    if (!syncToLocationSearch) {
+      const {
+        querySetter,
+        location,
+        history,
+        nsParams,
+      } = this.props;
+
+      const {
+        searchFields,
+        filterFields,
+        sortFields,
+      } = this.state.default;
+
+      // on unmount component should reset the query to its initial state.
+      const values = { query: '', qIndex: '', ...searchFields, ...filterFields, ...sortFields };
+
+      const nsValues = mapNsKeys(values, nsParams);
+
+      querySetter({ location, history, nsValues, values, nsParams, state: this.state });
+    }
+
+    if (onComponentWillUnmount) {
+      onComponentWillUnmount();
+    }
+  }
+
+  onChangeSearchState = (stateToSet) => {
+    this.internalSetState({ searchFields: stateToSet }, 'search.state');
+  }
+
+  onChangeSearchValue = (value, name) => {
+    // this.setState({ [fieldName]: query }, () => this.props.searchChangeCallback(query));
+    this.internalSetState(
+      {
+        searchFields: {
+          ...this.state.searchFields,
+          [name]: value,
+        }
+      },
+      'search.value',
+    );
+  };
+
+  onChangeSearchEvent = (e) => {
+    const query = e.target.value;
+    const fieldName = e.target.name;
+    // this.setState({ [fieldName]: query }, () => this.props.searchChangeCallback(query));
+    this.internalSetState(
+      {
+        searchFields: {
+          ...this.state.searchFields,
+          [fieldName]: query,
+        }
+      },
+      'search.event',
+    );
+  };
+
+  internalSetState = (stateToSet, changeType, callbacks) => {
+    const {
+      queryStateReducer,
+    } = this.props;
+    this.setState(curState => {
+      const nextState = { ...curState, ...stateToSet };
+      nextState.changeType = changeType;
+      nextState.searchChanged = !isEqual(
+        nextState.searchFields,
+        curState.default.searchFields
+      );
+      nextState.filterChanged = !isEqual(
+        nextState.filterFields,
+        curState.default.filterFields
+      );
+      nextState.sortChanged = !isEqual(nextState.sortFields, curState.default.sortFields);
+      return queryStateReducer(curState, nextState);
+    },
+    () => {
+      if (callbacks) {
+        callbacks.forEach((cb) => {
+          cb(this.state);
+        });
+      }
+    });
+  }
+
+  onSubmitAll = (dbounce = true) => {
+    const {
+      searchFields,
+      filterFields,
+      sortFields
+    } = this.state;
+
+    // convert filters to params (similar to this.applyFilters())
+    const filterParams = this.props.filtersToParams(filterFields);
+
+    const params = { ...searchFields, ...filterParams, ...sortFields };
+
+    if (dbounce) {
+      this.debouncedCallQuerySetter(params);
+    } else {
+      this.callQuerySetter(params);
+    }
+  }
+
+  onSubmitSearch = (e) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    this.debouncedCallQuerySetter(this.state.searchFields);
+  };
+
+  // eslint-disable-next-line react/sort-comp
+  debouncedCallQuerySetter = debounce((searchFields) => {
+    // this.log('action', `searched for '${searchFields}'`);
+    this.callQuerySetter({ ...searchFields });
+  }, 350);
+
+  onClearSearchFields = () => {
+    const { searchChangeCallback } = this.props;
+    // this.log('action', 'cleared search');
+    this.internalSetState(
+      { searchFields: {} },
+      'search.clear',
+      [
+        searchChangeCallback
+      ]
+    );
+  };
+
+  onResetSearch = (submit = true) => {
+    const submitCallback = submit ? () => { this.onSubmitSearch(); } : noop;
+    const { searchChangeCallback } = this.props;
+    // this.log('action', 'cleared search');
+    this.internalSetState(
+      {
+        searchFields: cloneDeep(this.state.default.searchFields)
+      },
+      'search.reset',
+      [
+        searchChangeCallback,
+        submitCallback
+      ]
+    );
+  }
+
+  onClearSearchAndFilters = () => {
+    const {
+      filterChangeCallback,
+      searchChangeCallback,
+      sortChangeCallback
+    } = this.props;
+    // this.log('action', 'cleared search and filters');
+    this.internalChangeState(
+      { searchFields: {}, filterFields: {}, sortFields: {} },
+      'clear.all',
+      [filterChangeCallback, searchChangeCallback, sortChangeCallback]
+    );
+  };
+
+  resetAll = (submit = true) => {
+    const {
+      filterChangeCallback,
+      searchChangeCallback,
+      sortChangeCallback,
+    } = this.props;
+
+    const submitCallback = submit ? () => { this.onSubmitAll(); } : noop;
+    // this.log('action', 'cleared search');
+    this.internalSetState(
+      {
+        ...cloneDeep(this.state.default)
+      },
+      'reset.all',
+      [
+        searchChangeCallback,
+        filterChangeCallback,
+        sortChangeCallback,
+        submitCallback
+      ]
+    );
+  }
+
+  onSort = (e, meta) => {
+    const { maxSortKeys, sortableColumns } = this.props;
+    const newOrder = meta.name;
+
+    if (sortableColumns && !includes(sortableColumns, newOrder)) return;
+
+    const oldOrder = this.queryParam('sort');
+    const orders = oldOrder ? oldOrder.split(',') : [];
+    const mainSort = orders[0];
+    const isSameColumn = mainSort && newOrder === mainSort.replace(/^-/, '');
+
+    if (isSameColumn) {
+      orders[0] = `-${mainSort}`.replace(/^--/, '');
+    } else {
+      orders.unshift(newOrder);
+    }
+
+    const sortOrder = orders.slice(0, maxSortKeys).join(',');
+
+    // this.log('action', `sorted by ${sortOrder}`);
+    this.callQuerySetter({ sort: sortOrder });
+  };
+
+  callQuerySetter = values => {
+    const {
+      location,
+      history,
+      nsParams,
+      querySetter,
+    } = this.props;
+
+    const nsValues = mapNsKeys(values, nsParams);
+
+    /* parent component is in control of actually applying local resource/query updates.
+    *  This way this component can work with different means of getting data -
+    *  location-based queries, local resource queries, possibly GraphQL...
+    */
+    querySetter({ location, history, nsValues, values, nsParams, state: this.state });
+  };
+
+  queryParam(name) {
+    const {
+      nsParams,
+      queryGetter,
+      location,
+    } = this.props;
+    const nsKey = getNsKey(name, nsParams);
+    const query = queryGetter({ location });
+    return get(query, nsKey);
+  }
+
+  onChangeFilterState = (stateToSet) => {
+    this.internalSetState(
+      { filterFields: stateToSet },
+      'filter.state',
+      [
+        () => {
+          this.applyFilters(this.state.filterFields);
+        }
+      ]
+    );
+  }
+
+  onFilterCheckboxChange = (e) => {
+    const { filterChangeCallback } = this.props;
+    const target = e.target;
+    const filterSplit = target.name.split('.');
+    const filterName = filterSplit[0];
+    const filterValue = filterSplit[1];
+
+    const nextState = cloneDeep(this.state);
+
+    if (nextState.filterFields[filterName]) {
+      const itemIndex = nextState.filterFields[filterName].findIndex(i => i === filterValue);
+      if (target.checked) {
+        if (itemIndex === -1) {
+          nextState.filterFields[filterName].push(filterValue);
+        }
+      } else if (itemIndex !== -1) {
+        nextState.filterFields[filterName].splice(itemIndex, 1);
+        // remove empties
+        if (nextState.filterFields[filterName].length === 0) {
+          delete nextState.filterFields[filterName];
+        }
+      }
+    } else {
+      nextState.filterFields[filterName] = [filterValue];
+    }
+
+    this.internalSetState(
+      nextState,
+      'filter.checkbox',
+      [
+        filterChangeCallback,
+        () => {
+          this.applyFilters(this.state.filterFields);
+        }
+      ]
+    );
+  }
+
+  onClearFilterGroup = (name) => {
+    const {
+      filterChangeCallback
+    } = this.props;
+
+    this.internalSetState(
+      {
+        filterFields: {
+          ...this.state.filterFields,
+          [name]: [],
+        }
+      },
+      'filter.clearGroup',
+      [
+        filterChangeCallback,
+        () => {
+          this.applyFilters(this.state.filterFields);
+        }
+      ]
+    );
+  }
+
+  onClearFilter = () => {
+    const {
+      filterChangeCallback
+    } = this.props;
+    this.internalSetState(
+      {
+        filterFields: {}
+      },
+      'filter.clear',
+      [
+        filterChangeCallback,
+        () => {
+          this.applyFilters(this.state.filterFields);
+        }
+      ]
+    );
+  }
+
+  onResetFilter = () => {
+    const {
+      filterChangeCallback
+    } = this.props;
+
+    this.internalSetState(
+      {
+        filterFields: cloneDeep(this.state.default.filterFields)
+      },
+      'filter.reset',
+      [
+        filterChangeCallback,
+        () => {
+          this.applyFilters(this.state.filterFields);
+        }
+      ]
+    );
+  }
+
+  applyFilters = (activeFilters) => {
+    // in the default setup, filterToParams stringifys the filter query state and
+    // packs it into an object with a "filters" key.
+    // This behavior is overridden with the filtersToParams prop.
+    const paramObject = this.props.filtersToParams(activeFilters);
+    const { searchFields } = this.state;
+
+    this.callQuerySetter({ ...searchFields, ...paramObject });
+  }
+
+  getActiveFilterState = () => {
+    const filtersString = this.queryParam('filters') || '';
+
+    if (filtersString.length === 0) {
+      return undefined;
+    }
+
+    return filtersString
+      .split(',')
+      .reduce((resultFilters, currentFilter) => {
+        const [filterName, filterValue] = currentFilter.split('.');
+
+        if (!Array.isArray(resultFilters[filterName])) {
+          resultFilters[filterName] = [];
+        }
+
+        resultFilters[filterName].push(filterValue);
+
+        return resultFilters;
+      }, {});
+  }
+
+  getFilterChangeHandlers = () => ({
+    state: this.onChangeFilterState,
+    checkbox: this.onFilterCheckboxChange,
+    clear: this.onClearFilter,
+    clearGroup: this.onClearFilterGroup,
+    reset: this.onResetFilter,
+  });
+
+  getActiveFilters = () => ({
+    state: this.state.filterFields,
+    string: this.props.filtersToString(this.state.filterFields),
+  });
+
+  getSearchChangeHandlers = () => ({
+    state: this.onChangeSearchState,
+    query: this.onChangeSearchEvent,
+    clear: this.onClearSearchFields,
+    reset: this.onResetSearch,
+  });
+
+  render() {
+    const { children } = this.props;
+
+    return children({
+      filterChanged: this.state.filterChanged,
+      searchChanged: this.state.searchChanged,
+      sortChanged: this.state.sortChanged,
+      getSearchHandlers: this.getSearchChangeHandlers,
+      searchValue: this.state.searchFields,
+      onSubmitSearch: this.onSubmitSearch,
+      getFilterHandlers: this.getFilterChangeHandlers,
+      onSort: this.onSort,
+      activeFilters: this.getActiveFilters(),
+      resetAll: this.resetAll,
+    });
+  }
+}
+
+export default withRouter(SearchAndSortQuery);

--- a/src/components/SearchAndSort/SearchAndSortQuery.md
+++ b/src/components/SearchAndSort/SearchAndSortQuery.md
@@ -1,0 +1,254 @@
+# `<SearchAndSortQuery>`
+
+A non-presentational version of SearchAndSort, it focuses on assisting with glue code surrounding the Search/Filter pattern that's common among FOLIO apps. This leaves the presentation open to modification for requirements.
+
+## Query state...
+`<SearchAndSortQuery>` stores a query as 3 separate slices of its internal state: `searchFields`, `sortFields`, and `filterFields`. Ultimately these are transformed into a single query string and applied as query parameters. The method of transformation is adjustable via props, with the most typical case supplied by default. The typical query shape of SearchAndSort apps within the FOLIO ecosystem currently resembles the following.
+```
+{
+  searchFields: {
+    query: '',
+  },
+  filterFields: {
+    filters: '<group>.<filtername>, ...',
+  },
+  sortFields: {
+    sort: '<fieldName>`,
+  }
+}
+```
+If the user has searched for 'ba', filtered by 'faculty' and 'staff' under the 'patron group' (pg) group, and the list is sorted by name, the generated query string for this appears as `filters=pg.faculty%2Cpg.staff&query=ba&sort=name`.
+
+## Render Props
+
+This component supplies change handlers and values for search and filter controls via render-props. It accepts a function as a child, and the supplied render-prop parameters are assigned to the children therein.
+
+Name | member | type | description
+--- | --- | --- | ---
+`getSearchHandlers` | | func | returns an object of search handlers.
+| | `getSearchHandlers().query` | func | event handler for inputs - accepts and event and assigns the value to a field of the component's 'name' attribute.
+| | `getSearchHandlers().state` | func | event handler that accepts an object to set as the 'search' slice of internal state.
+| | `getSearchHandlers().reset` | func | event handler for resetting searchFields back to an initial state.
+`searchValue` | | object |  returns the 'search' slice of internal state,
+`onSubmitSearch` | | func | for search triggers
+`getFilterHandlers` | | func | returns an object of filter handlers.
+| | `getFilterHandlers().state` | func | accepts an object to set as the 'filterFields' slice of internal state.
+| | `getFilterHandlers().clear` | func | convenience handler for clearing filters.
+| | `getFilterHandlers().clearGroup` | func | convenience handler for clearing `<FilterGroups>` - the function accepts a 'name' for the filter and clears that key in the query state.
+| | `getFilterHandlers().checkbox` | func | convenience handler for checkboxes/radio button controls.
+| | `getFilterHandlers().reset` | func | convenient for reseting filters back to an initial state, rather than clearing them.
+`activeFilters` | | object | an object of active filters in a variety of formats,
+| | `activeFilters.state` | object | the current `filterFields` slice of internal state.
+| | `activeFilters.string` | string | string representation of filters.
+`resetAll` | | func | convenient handler for resetting search, filters, and sorting to 'initial values'
+`filterChanged` | bool | Boolean whether or not filters are different from their defaults. Useful for displaying 'reset' controls.
+`searchChanged` | bool | Similar to `filterChanged` for search criteria.
+`sortChanged` | bool | Similar to `filterChanged` for sort fields.
+
+## Props
+
+`<SearchAndSortQuery>` allows you to override its functionality as needed to suit your module's needs.
+
+Name | type | description | required | default
+--- | --- | --- | --- | ---
+`children` | func | the child function that accepts the render props. | :check |
+`filtersToString` | func | prop to convert the `filterFields` slice of state to a string for query building. Has to return a string. | | Generates comma-separated lit of `<name>.<value>` pairs. E.G. `pg.faculty,pg.staff,pg.student`
+`filterParamsMapping` | object | Object containing key/function pairs for converting existing filters to query state. InitializeFilters converts the array of `group.filtername` to an object keyed on groups with arrays of the active. | | `{ 'filters': initializeFilters }`
+`initialSearch` | string | The initial query that should initialize the component. | |
+`initialSearchState` | object | sets up the inital state of the `searchFields` slice of query state. | |
+`initialFiltersState` | object | sets up the inital state of the `filterFields` slice of query state. | |
+`initialSortState` | object | sets up the initial state of the `sortFields` slice of query state. | |
+`maxSortKeys` | number | If provided, specifies that maximum number of sort-keys that should be remembered for "stable sorting". | | 2
+`sortableColumns` | array | If provided, specifies the columns that can be sorted.
+`nsParams` | string, object | For instances where namespacing params due to a shared query string is necessary. A string will place the string in front of the parameter separated by a dot. An object can be used for name-spacing on a per-parameter basis. | |
+`onComponentWillUnmount` | func | for performing any necessary cleanup when the component dismounts. | | The component alone will reset the query to the initial query.
+`queryGetter` | func | An adapter function called internally for querying parameters. Its passed the an object containing the `location` object from react-router. | | By default, it returns the search key of location, parsed via `queryString.parse`
+`querySetter` | func | An adapter function for applying your query. It's passed an object with `location`, `history` object, `values` (pre and post namespace), as well as the internal `state` of the component - all potentially useful for constructing and applying your query. | | By default it builds the url and applies it via `history.push`
+`searchParamsMapping` | object | Object containing key/function pairs for converting pre-existing search parameters to query state | | `{ 'query': v => v }`
+`sortParamsMapping` | object | Object containing key/function pairs for converting pre-existing sorting parameters to query state. | | `{ 'sort': v => v }`
+`queryStateReducer` | func | Powerful function that allows for manipulation of the internal state of the component with each change. Simply return the state that you need to be set. | | `(curState, nextState) => nextState`
+`searchChangeCallback`, `filterChangeCallback`, `sortChangeCallback` | func | Callbacks to apply other updates within your application when their corresponding slice of internal state.
+`syncToLocationSearch` | bool | If `false`, this component will not update based on changes to the browser's location. This is ideal for sub-module searches and plug-ins that work solely of local resources and do not affect the browsers' location. With the `true` setting, this component will respond to changes in the browser's query string - this works with direct linking and resetting via link. | | `true`
+
+## Example Usage
+
+```
+<SearchAndSortQuery
+  querySetter={this.querySetter}
+  queryGetter={this.queryGetter}
+  onComponentWillUnmount={onComponentWillUnmount}
+  initialSearchState={{ query: '' }}
+>
+  {
+    ({
+      searchValue,
+      getSearchHandlers,
+      onSubmitSearch,
+      onSort,
+      getFilterHandlers,
+      activeFilters,
+    }) => (
+      <div>
+        <TextField
+          label="user search"
+          name="query"
+          onChange={getSearchHandlers().query}
+          value={searchValue.query}
+        />
+        <Button onClick={onSubmitSearch}>Search</Button>
+        <Filters
+          onChangeHandlers={getFilterHandlers()}
+          activeFilters={activeFilters}
+          config={filterConfig}
+          patronGroups={patronGroups}
+        />
+        <IntlConsumer>
+          { intl => (
+            <MultiColumnList
+              visibleColumns={this.props.visibleColumns ? this.props.visibleColumns : ['status', 'name', 'barcode', 'patronGroup', 'username', 'email']}
+              contentData={get(resources, 'records.records', [])}
+              columnMapping={{
+                status: intl.formatMessage({ id: 'ui-users.active' }),
+                name: intl.formatMessage({ id: 'ui-users.information.name' }),
+                barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
+                patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),
+                username: intl.formatMessage({ id: 'ui-users.information.username' }),
+                email: intl.formatMessage({ id: 'ui-users.contact.email' }),
+              }}
+              formatter={resultsFormatter}
+              rowFormatter={this.anchorRowFormatter}
+              onRowClick={onSelectRow}
+              onNeedMore={this.onNeedMore}
+              onHeaderClick={onSort}
+            />
+          )}
+        </IntlConsumer>
+      </div>
+    )
+  }
+</SearchAndSortQuery>
+```
+
+## Using QueryGetter and QuerySetter
+These are adapter functions used to get and set your your query according to your particular modules needs. Some modules may use the window location (default functionality), others may need to update the query via the mutator (local resource.) A basic example: using the local resource...
+
+```
+// nsValues simply return the base value name if no namespacing is provided.
+  querySetter = ({ nsValues }) => {
+    this.props.mutator.query.update(nsValues);
+  }
+
+  queryGetter = () => {
+    return get(this.props.resources, 'query', {});
+  }
+```
+
+## changeType
+The query state contains a field named `changeType` that relays information about which particular action triggered a state change. This status is relayed out to `queryStateReducer` as well as `querySetter` so that logic can differ there if it needs to. For example, in instances where a user resets their search and filters, you may opt to replace a query rather than just update it:
+
+```
+querySetter = ({ nsValues, state }) => {
+    if (/reset/.test(state.changeType)) {
+      this.props.mutator.query.replace(nsValues);
+    } else {
+      this.props.mutator.query.update(nsValues);
+    }
+  }
+```
+
+## queryStateReducer
+This function allows you ultimate control over the internal query state with every change. It's necessary to maintain the `searchFields`,`filterFields`,`sortFields` keys, but otherwise, you can update internal state and subfields however you'd like. The `nextState.changeType` field allows you branch logic as needed depending on the cause of the change. For a contrived example, have a filter modify sorting in a particular way...
+
+```
+const filterSort = (curState, nextState) => {
+  const stateToSet = cloneDeep(nextState);
+  switch (nextState.changeType) {
+    case 'filter.state':
+      if (nextState.filterFields.alpha.length > 0) {
+        stateToSet.sortFields.direction = 'ascending';
+      }
+      break;
+    default:
+      return nextState;
+  }
+  return stateToSet;
+}
+```
+
+## Initializing the query state
+By default, `<SearchAndSortQuery>` will initialize its query state using its 'location' prop - this comes from the url in the address bar. SearchAndSort-based modules include their default queries in their 'home' url ex: `/users?sort=name`.
+If using the local resource strictly for your query string (typical plugin behavior), you can set the `syncToLocationSearch` prop to `false` and supply an `initialSearch` prop with the search string beginning with `?` - ex: `initialSearch="?sort=name"`
+
+## Resetting
+`<SearchAndSortQuery>` will use the `initialSearch` prop to reset its query state for any 'reset' functionality for filters and search criteria.
+
+## Parameter mapping
+Three props: `searchParamsMapping`, `filterParamsMapping`, `sortParamsMapping` allow for you to inform `SearchAndSortQuery` how to derive query state based on pre-existing query params. Defaults for the props are provided that conform to FOLIO's most common case.
+This is a contrived example using a custom query string structure:
+```
+https://not-a-real-thing/search?name=blue&startdate=03%2F05%2F1996&enddate=09%2F04%2F2003&countries=paraguay%2Cmexico%2Ccanada&sort=name&direction=true
+```
+
+```
+// these can be reusable...
+const clone = v => v;
+
+{
+  <SearchAndSortQuery
+    searchParamsMapping={{
+      name: clone,
+      startdate: clone,
+      enddate: clone,
+    }}
+    filterParamsMapping={{
+      countries: v => v.split(','),
+      type: clone,
+    }},
+    sortParamsMapping={{
+      sort: clone,
+      direction: v => v === 'true' ? 'ascending' : 'descending',
+    }},
+  >
+    {(...render) => (children(...render))}
+  </SearchAndSortQuery>
+}
+```
+
+### Using a slice of `initialState`
+Blank values are a use-case that may not be captured at all in `initialSearch` or the location query. Internal logic removes these values before applying them to the browser location, so they cannot be derived from the location itself - so we need another means to do so. `initialSearchState`, `initialFilterState` and `initialSortState` are all props that, as their name suggests, supply the component with a default query state for **initialization and resets** - this includes a way to apply blank values - or any value if it isn't present in the browser location.
+```
+<SearchAndSortQuery
+  initialSortState={{ sort: 'name' }}
+  initialSearchState={{ query: '', qindex: '' }}
+> ...
+</SearchAndSortQuery>
+```
+
+## The `<Filter>` component
+
+The `<Filter>` component shown in the example is a per-module component that's dedicated to rendering filter controls and supplying their lowest level handling needs internally. It isn't always necessary, but a nice way to tuck filter UI into the code. It ideal for it to accept the `filterFields` slice of the state as it's single source of truth for its values and speak back to `SearchAndSortQuery` via the `getFilterHanders().state` handler to apply updates back to the component.
+
+## Migrating with FilterGroups
+
+`<FilterGroups>` are the default filter component rendered by `<SearchAndSort>` They render based on a `filterConfig` object and form a nice boolean filter set-up within most FOLIO apps. Migrating to this, `<FilterGroups>` from stripes-components will accept the application's filter config (`config` prop), and an object with boolean keys - `true` for each active filter (`filters` prop), and a handler for clearing the group via its clear button on the accordion header.
+Here's a snippet from within the `<Filters>` component of `ui-plugin-find-user` that uses `<FilterGroup>`. The `activeFilters` and `onChangeHandlers` props come straight from the render props of `<SearchAndSortQuery>`.
+
+```
+  const {
+      activeFilters,
+      onChangeHandlers: { checkbox, clearGroup },
+      config,
+    } = this.props;
+
+    const groupFilters = {};
+    activeFilters.string.split(',').forEach(m => { groupFilters[m] = true; });
+
+    return (
+      <FilterGroups
+        config={config}
+        filters={groupFilters}
+        onChangeFilter={checkbox}
+        onClearFilter={clearGroup}
+      />
+    );
+```

--- a/src/components/SearchAndSort/buildUrl.js
+++ b/src/components/SearchAndSort/buildUrl.js
@@ -1,0 +1,34 @@
+import queryString from 'query-string';
+import {
+  unset,
+  isEmpty,
+  forOwn,
+} from 'lodash';
+
+function getLocationQuery(location) {
+  return location.query ? location.query : queryString.parse(location.search);
+}
+
+function removeEmpty(obj) {
+  const cleanObj = {};
+
+  forOwn(obj, (value, key) => {
+    if (value) cleanObj[key] = value;
+  });
+
+  return cleanObj;
+}
+
+export default function buildUrl(location, values, basePath) {
+  const locationQuery = getLocationQuery(location);
+  let url = values._path || basePath || location.pathname;
+  const params = removeEmpty(Object.assign(locationQuery, values));
+
+  unset(params, '_path');
+
+  if (!isEmpty(params)) {
+    url += `?${queryString.stringify(params)}`;
+  }
+
+  return url;
+}

--- a/src/components/SearchAndSort/building-filters.md
+++ b/src/components/SearchAndSort/building-filters.md
@@ -1,0 +1,196 @@
+# Building filters for your Stripes app
+
+<!-- md2toc -l 2 building-filters.md -->
+* [Introduction](#introduction)
+* [Representation](#representation)
+    * [Representation in the URL](#representation-in-the-url)
+    * [Representation in memory](#representation-in-memory)
+* [Strategy](#strategy)
+    * [1. Render the filters in our own code](#1-render-the-filters-in-our-own-code)
+    * [2. Populate initial selected values from `filters`](#2-populate-initial-selected-values-from-filters)
+    * [3. On interaction, go to a URL with modified `filters`](#3-on-interaction-go-to-a-url-with-modified-filters)
+    * [4. Configure the query-generating function](#4-configure-the-query-generating-function)
+* [Example: `ui-directory`](#example-ui-directory)
+    * [Stage 1.](#stage-1)
+    * [Stage 2.](#stage-2)
+    * [Stage 3.](#stage-3)
+    * [Stage 4.](#stage-4)
+* [Conclusion](#conclusion)
+
+
+
+## Introduction
+
+As with so many things in the world of Stripes, there are several different ways to add filters to your app. Just as the main app framework can be provided by [`<SearchAndSort>`](readme.md) or [`<SearchAndSortQuery>`](SearchAndSortQuery.md) &mdash; which provide broadly equivalent capabilities but with very different APIs &mdash; so filters can be implemented using [`<FilterGroups>`](https://github.com/folio-org/stripes-components/blob/master/lib/FilterGroups/readme.md) augmented with `initialFilterState` and `filters2cql`, or using `filterState` instead of `initialFilterState`, and with either `onChangeFilter` or `handleFilterChange`, and so the options go on.
+
+As helpful as these approaches can be, they all have a tendency to break down once you start wanting to use more complex kinds of filters, such as the [`<MultiSelectionFilter>`](components/MultiSelectionFilter/MultiSelectionFilter.js) control that lets you search within a large vocabulary of potential filter values. Given the potentially bewildering variety of APIs that can be used and
+the flexibility that inevitably becomes necessary, the best solution may be to roll one's own filters from parts.
+
+
+
+## Representation
+
+
+### Representation in the URL
+
+There are several functions that can be used in a stripes-connect `manifest` entry to generate a query for the back-end based on the contents of the URL's query parameters. [`makeQueryFunction`](readme.md#makequeryfunction) generates CQL, suitable for submitting to [RMB](https://github.com/folio-org/raml-module-builder)-based back-end modules; [`getSASparams`](https://github.com/folio-org/stripes-erm-components/blob/master/lib/getSASParams.js) does a similar job for back-end modules that use Knowlege Integration's Grails-based back-end; and [`generateQueryParams`](https://github.com/folio-org/stripes-erm-components/blob/master/lib/generateQueryParams.js) is a newer alternative. Fortunately all three use the same representation of filters in the URL:
+
+* a single URL query parameter called `filters`,
+* consisting of a comma-separated series of entries,
+* each of the form `key`.`value`,
+* where multiple entries may share the same key (but different values)
+
+So a URL containing `filters=state.REQ_CANCELLED,state.REQ_END_OF_ROTA,supplier.123` specifies three values:
+
+* key `state`, value `REQ_CANCELLED`
+* key `state`, value `REQ_END_OF_ROTA`
+* key `supplier`, value `123`
+
+(The generated query finds records that have _any_ of the values specified for each key that is mentioned: so in the example above, something like `state=(REQ_CANCELLED or REQ_END_OF_ROTA) and supplier=123`.)
+
+
+### Representation in memory
+
+The various utility functions mentioned above all deal with this representation in one way or another, but the simplest way to address it is with [the `parseFilters` and `deparseFilters` functions](parseFilters.js), which convert from this string representation to an in-memory structure that is easy to manipulate, and back again.
+
+The in-memory structure is an objects whose keys are those that are mentioned in the filter string, and whose corresponding values are arrays containing all of the values specified for each key. So:
+
+	const filters = 'state.REQ_CANCELLED,state.REQ_END_OF_ROTA,supplier.123';
+	console.log('filters =', filters);
+	const struct = parseFilters(filters);
+	console.log('struct =', struct);
+	const res = deparseFilters(struct);
+	console.log('res =', res);
+
+Yields:
+
+	filters = state.REQ_CANCELLED,state.REQ_END_OF_ROTA,supplier.123
+	struct = { state: [ 'REQ_CANCELLED', 'REQ_END_OF_ROTA' ], supplier: [ '123' ] }
+	res = state.REQ_CANCELLED,state.REQ_END_OF_ROTA,supplier.123
+
+
+
+## Strategy
+
+Here is how we will build the filtering code for our app:
+
+1. Render the filters in our own code
+2. Populate initial selected values from `filters`
+3. On interaction, go to a URL with modified `filters`
+4. Configure the query-generating function
+
+We do not use component state &mdash; the URL _is_ the state. And we do not use a `filterConfig` structure.
+
+Now let's look at these steps in more detail.
+
+
+### 1. Render the filters in our own code
+
+We will render the filters in our own code rather that having it it done by a library component (which is likely to be insufficiently flexible). When using `<SearchAndSortQuery>`, it's easy to include a component that renders the filters; but `<SearchAndSort>` also has a facility for doing this: you can pass in a `renderFilters` prop whose value is a function that will be invoked to render the filters, in place of those that would otherwise be generated from a filter-config.
+
+Rendering the filter involves generating the lists of candidate values, which can itself be a complex procedure. For that reason, it is sometimes best to have the `renderFilters` function simply assemble the lists of candidate values, then pass those through to a `renderFiltersFromData` function that uses those lists to render the actual controls: `<Select>`s, sets of `<Checkbox>`es, `<MultiSelectionFilter>`s, `<Datepicker>`s or whatever else is useful.
+
+It is necessary to provide the callback functions that are invoked when the user interacts with a control: see stage 3 for this.
+
+
+### 2. Populate initial selected values from `filters`
+
+When rendering the filter controls, we have to populate their initial selected values from the `filters` specified in the URL. This is simple to do: we just get the `filters` parameter from [the special stripes-connect resource `query`](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#url-navigation), parse it with `parseFilters`, and use the arrays in the resulting object to populate the initial value of each control.
+
+	import { parseFilters, deparseFilters } from '@folio/stripes/smart-components';
+	const byName = parseFilters(get(resources.query, 'filters'));
+	const values = {
+	  institution: byName.supplier || [],
+	  // ... and other values
+	};
+
+	// Then, later:
+	<MultiSelectionFilter
+	  name="supplier"
+	  dataOptions={options.institution}
+	  selectedValues={values.institution}
+	  onChange={setFilterState}
+	/>
+	// ... and others filter controls
+
+(The `<MultiSelectionFilter>` control takes an array of scalars as its values; sets of `<Checkbox>`es can also be populated by these arrays. Most other controls will expect a single value.)
+
+
+### 3. On interaction, go to a URL with modified `filters`
+
+When the user interacts with a filter, a callback function is called &mdash; `setFilterState` in the example above. The function should use the event target that is its argument to find the chosen value, then modify the parsed filter structure accordingly, then deparse the structure into a new filter string, and finally navigate to the URL with the modified value of `filters`. This navigation can most conveniently be achieved by mutating the special stripes-connect resource `query`, so:
+
+	const setFilterState = (group) => {
+	  if (group.values === null) {
+	    delete byName[group.name];
+	  } else {
+	    byName[group.name] = group.values;
+	  }
+	  mutator.query.update({ filters: deparseFilters(byName) });
+	};
+
+It is not necessary to labouriously track filter changes in local component state, as some of the existing solutions do: the URL _is_ the state, containing everything necessary to render the filters and capable of capturing every change that the user can make to them.
+
+
+### 4. Configure the query-generating function
+
+Steps 1 to 3 above suffice to maintain the value of the `filters` parameter in the URL. The last step is for the query-generation function &mdash; usually generated by one of `makeQueryFunction`, `getSASparams` or `generateQueryParams` &mdash; to turn that filter string into a query for the back-end module. In general these functions do the right thing, but some configuration is necessary to ensure that the queries use the correct indexes.
+
+For `getSASparams` and `generateQueryParams`, this is done using the `filterKeys` entry in the configuration object. This is an object whose values are filter names as they appear in the `filters` string in the URL, and whose values are the corresponding back-end indexes to search in.
+
+For example, the `supplier` key in the example above might provide values to be searched for in the `resolvedSupplier.owner.id` field. This would be specified by providing a `manifest` entry whose parameters are generated as follows:
+
+	params: generateQueryParams({
+	  filterKeys: {
+	    'supplier': 'resolvedSupplier.owner.id',
+	  },
+	}),
+
+In `generateQueryParams`, if you omit the filterKey for a key in the query, only the value will be passed through to the backend. This is useful if you want to use an operation other than ==. For example, if you have `'foo': 'bar'` in your `filterKeys` and something like `foo.42` in your URL it will send that as `bar==42` but you could make a comparison by omitting foo from `filterKeys` and setting the value as `bar>42`. That will show up in the URL as `foo.bar>42` and be sent as `bar>42`.
+
+## Example: `ui-directory`
+
+[The `ui-directory` module](https://github.com/openlibraryenvironment/ui-directory) provides a means to maintain the directory of libraries, branches and consortia in the [ReShare](https://projectreshare.org/) resource-sharing platform. As of [commit 84f94d0a](https://github.com/openlibraryenvironment/ui-directory/tree/84f94d0a3414577fbb4903344d09ce4712d19d6e) of 7 April 2020, the whole of the filtering code is in a single source file, [the top-level routing component](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js), which makes it easy to understand for tutorial purposes. It provides two multi-select filters named `type` and `tags`.
+
+Here are the parts of the code that implement the four stages in the strategy above:
+
+
+### Stage 1.
+
+* [Line 284](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L284) passes the `renderFilters` method into `<SearchAndSort>`
+* [Lines 215-224](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L215-L224) implement this function, gathering candidate values for the two filters and passing them into `renderFiltersFromData`.
+* [Lines 166-204](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L166-L204) implement `renderFiltersFromData` which actually render the filters. This is where most of the real work is done.
+
+
+### Stage 2.
+
+* The first thing `renderFiltersFromData` does is to parse the `filters` string, deriving an in-memory representation, and use this to derive a set of `values` ([lines 168-173](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L168-L173)).
+* These values are used to provide the current selections in the `<MultiSelectionFilter>` ([line 199](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L199)).
+
+
+### Stage 3.
+
+* [Line 200](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L200) specifies that when a filter control changes, the `setFilterState` method should be called.
+* [line 194](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L194) provides a callback for clearing the filter completely: the very simple `clearGroup` function provided in [line 183](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L183), which merely invokes `setFilterState` with an empty set of values.
+* `setFilterState` ([lines 175-182](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L175-L182)) simply modifies the parsed filter representation, then in its last line updates the special stripes-connect resource `query` to set the `filters` parameter to the result of deparsing the modified in-memory representation of the filters.
+
+
+### Stage 4.
+
+* The code we have seen so far arranges for the `filters` parameter of the URL to contain values for filters named `type` and `tags`. The `filterKeys` parameter of the `getSASparams` function ([lines 54-57](https://github.com/openlibraryenvironment/ui-directory/blob/84f94d0a3414577fbb4903344d09ce4712d19d6e/src/routes/DirectoryEntries.js#L54-L57]) specifies how to translate those filter-names into queriable indexes.
+
+The result of all this is that if the user, for example, selects two tags, "storage" and "pickup", then the URL will contain the `filters` parameter `tags.Storage,tags.Pickup`, and the corresponding back-end query will be generated: `/directory/entry?filters=tags.value%3D%3DStorage%7C%7Ctags.value%3D%3DPickup`.
+
+
+
+
+## Conclusion
+
+This approach to providing filters has the following benefits:
+
+* The code is simple and easy to follow.
+* There is little "magic" involved &mdash; the reason for each piece of code is readily apparent.
+* It is easy to extend the filter pane with any combination of controls.
+
+
+

--- a/src/components/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/src/components/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Checkbox } from '@folio/stripes-components';
+import { kebabCase } from 'lodash';
+
+export default class CheckboxFilter extends React.Component {
+  static propTypes = {
+    dataOptions: PropTypes.arrayOf(PropTypes.shape({
+      disabled: PropTypes.bool,
+      label: PropTypes.node,
+      readOnly: PropTypes.bool,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })).isRequired,
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    selectedValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  };
+
+  static defaultProps = {
+    selectedValues: [],
+  }
+
+  createOnChangeHandler = (filterValue) => (e) => {
+    const {
+      name,
+      selectedValues,
+      onChange,
+    } = this.props;
+
+    const newValues = e.target.checked
+      ? [...selectedValues, filterValue]
+      : selectedValues.filter((value) => value !== filterValue);
+
+    onChange({
+      name,
+      values: newValues,
+    });
+  };
+
+  render() {
+    const {
+      dataOptions,
+      selectedValues,
+      ...rest
+    } = this.props;
+
+    return (
+      dataOptions.map(({ value, label, disabled, readOnly }) => {
+        const name = typeof label === 'string' ? label : value;
+        return (
+          <Checkbox
+            {...rest}
+            id={`clickable-filter-${this.props.name}-${kebabCase(name)}`}
+            data-test-checkbox-filter-data-option={value}
+            key={value}
+            label={label}
+            name={name}
+            disabled={disabled}
+            readOnly={readOnly}
+            checked={selectedValues.includes(value)}
+            onChange={this.createOnChangeHandler(value)}
+          />
+        );
+      })
+    );
+  }
+}

--- a/src/components/SearchAndSort/components/CheckboxFilter/index.js
+++ b/src/components/SearchAndSort/components/CheckboxFilter/index.js
@@ -1,0 +1,1 @@
+export { default } from './CheckboxFilter';

--- a/src/components/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.css
+++ b/src/components/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.css
@@ -1,0 +1,9 @@
+/**
+ * CollapseFilterPaneButton
+ */
+
+@import '@folio/stripes-components/lib/variables';
+
+.button {
+  margin: calc(var(--gutter-static-two-thirds) * -1) !important;
+}

--- a/src/components/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
+++ b/src/components/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
@@ -1,0 +1,38 @@
+/**
+ * CollapseFilterPaneButton
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { PaneHeaderIconButton, Tooltip } from '@folio/stripes-components';
+import css from './CollapseFilterPaneButton.css';
+
+const CollapseFilterPaneButton = ({ onClick }) => {
+  const intl = useIntl();
+
+  return (
+    <Tooltip
+      text={intl.formatMessage({ id: 'stripes-smart-components.hideSearchPane' })}
+      id="collapse-filter-pane-button-tooltip"
+    >
+      {({ ref, ariaIds }) => (
+        <PaneHeaderIconButton
+          ref={ref}
+          aria-labelledby={ariaIds.text}
+          icon="caret-left"
+          iconSize="medium"
+          onClick={onClick}
+          className={css.button}
+          data-test-collapse-filter-pane-button
+        />
+      )}
+    </Tooltip>
+  );
+};
+
+CollapseFilterPaneButton.propTypes = {
+  onClick: PropTypes.func,
+};
+
+export default CollapseFilterPaneButton;

--- a/src/components/SearchAndSort/components/CollapseFilterPaneButton/index.js
+++ b/src/components/SearchAndSort/components/CollapseFilterPaneButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './CollapseFilterPaneButton';

--- a/src/components/SearchAndSort/components/CollapseFilterPaneButton/readme.md
+++ b/src/components/SearchAndSort/components/CollapseFilterPaneButton/readme.md
@@ -1,0 +1,7 @@
+# CollapseFilterPaneButton
+This button is used to collapse the filter pane. It should be placed in the `lastMenu` of the filters pane.
+
+## Props
+Name | Type | Description
+-- | -- | --
+onClick | func | Toggles the filter pane

--- a/src/components/SearchAndSort/components/DateRangeFilter/DateRange.css
+++ b/src/components/SearchAndSort/components/DateRangeFilter/DateRange.css
@@ -1,0 +1,7 @@
+@import '@folio/stripes-components/lib/variables.css';
+
+.validationMessage {
+  margin-bottom: 15px;
+  display: block;
+  color: var(--error);
+}

--- a/src/components/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/src/components/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -1,0 +1,292 @@
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { TextField, Button } from '@folio/stripes-components';
+
+import {
+  isDateValid,
+  validateDateRange,
+} from './date-validations';
+
+import DATE_TYPES from './date-types';
+
+import styles from './DateRange.css';
+
+const defaultFilterState = {
+  dateRangeValid: false,
+  errors: {
+    startDateInvalid: false,
+    endDateInvalid: false,
+    startDateMissing: false,
+    endDateMissing: false,
+    wrongDatesOrder: false,
+  },
+};
+
+export default class DateRangeFilter extends Component {
+  static propTypes = {
+    dateFormat: PropTypes.string,
+    makeFilterString: PropTypes.func.isRequired,
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    selectedValues: PropTypes.shape({
+      endDate: PropTypes.string.isRequired,
+      startDate: PropTypes.string.isRequired,
+    }).isRequired,
+  };
+
+  static defaultProps = {
+    dateFormat: 'YYYY-MM-DD'
+  };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const {
+      dateFormat,
+      selectedValues: nextSelectedDates,
+    } = nextProps;
+
+    const { prevSelectedDates } = prevState;
+
+    let validationDataUpdates = {};
+
+    const selectedDatesAreSetFirstTime =
+      (prevSelectedDates.startDate === '' && prevSelectedDates.endDate === '')
+      && (nextSelectedDates.startDate !== '' || nextSelectedDates.endDate !== '');
+
+    const selectedDatesAreReset =
+      nextSelectedDates.startDate === '' && nextSelectedDates.endDate === ''
+      && prevSelectedDates.startDate !== '' && prevSelectedDates.endDate !== '';
+
+    if (selectedDatesAreSetFirstTime) {
+      validationDataUpdates = validateDateRange(nextSelectedDates, dateFormat);
+    } else if (selectedDatesAreReset) {
+      validationDataUpdates = defaultFilterState;
+    }
+
+    return {
+      ...validationDataUpdates,
+      prevSelectedDates: nextSelectedDates
+    };
+  }
+
+  constructor(props) {
+    super(props);
+
+    const {
+      startDate,
+      endDate,
+    } = props.selectedValues;
+
+    this.startDateInput = React.createRef();
+    this.endDateInput = React.createRef();
+
+    this.state = {
+      ...this.getInitialValidationData(),
+      prevSelectedDates: {
+        startDate,
+        endDate,
+      },
+    };
+  }
+
+  getInitialValidationData() {
+    const {
+      startDate,
+      endDate,
+    } = this.props.selectedValues;
+
+    const dateRangeIsNotEmpty = startDate !== '' || endDate !== '';
+
+    return dateRangeIsNotEmpty
+      ? validateDateRange(this.props.selectedValues)
+      : defaultFilterState;
+  }
+
+  onApplyButtonClick = () => {
+    const {
+      applyFilterIfValid,
+      props: { dateFormat },
+    } = this;
+
+    const {
+      prevSelectedDates: {
+        startDate: prevStartDate,
+        endDate: prevEndDate,
+      }
+    } = this.state;
+
+    const dateRange = {
+      startDate: this.startDateInput.current.value,
+      endDate: this.endDateInput.current.value,
+    };
+    const bothDatesEmpty = dateRange.startDate === '' && dateRange.endDate === '';
+    const prevDatesWereSet = prevStartDate !== '' && prevEndDate !== '';
+    const filterWasReset = bothDatesEmpty && prevDatesWereSet;
+
+    if (filterWasReset) {
+      this.clearFilter();
+    } else if (!bothDatesEmpty) {
+      const validationData = validateDateRange(dateRange, dateFormat);
+      this.setState(validationData, applyFilterIfValid);
+    }
+  }
+
+  applyFilterIfValid = () => {
+    const { dateRangeValid } = this.state;
+
+    if (dateRangeValid) {
+      this.applyFilter();
+    }
+  };
+
+  applyFilter() {
+    const {
+      name: filterName,
+      onChange: setFilterValue,
+      makeFilterString,
+    } = this.props;
+
+    const startDate = this.startDateInput.current.value;
+    const endDate = this.endDateInput.current.value;
+
+    const filterString = makeFilterString(startDate, endDate);
+
+    setFilterValue({
+      name: filterName,
+      values: [filterString]
+    });
+  }
+
+  clearFilter() {
+    const {
+      name: filterName,
+      onChange: setFilterValue,
+    } = this.props;
+
+    setFilterValue({
+      name: filterName,
+      values: []
+    });
+  }
+
+  onDateBlur = (e) => {
+    const {
+      name: dateType,
+      value: date,
+    } = e.target;
+
+    const { dateFormat } = this.props;
+
+    const dateIsEmpty = date === '';
+
+    const dateIsInvalid = !dateIsEmpty && !isDateValid(date, dateFormat);
+    const errorName = `${dateType}Invalid`;
+
+    this.setState(prevState => ({
+      errors: {
+        ...prevState.errors,
+        [errorName]: dateIsInvalid
+      }
+    }));
+  }
+
+  renderInvalidDateError(dateType) {
+    return (
+      <span data-test-invalid-date={dateType}>
+        <FormattedMessage id="stripes-smart-components.dateRange.invalidDate" />
+      </span>
+    );
+  }
+
+  renderMissingDateError(dateType) {
+    const translationId = dateType === DATE_TYPES.START
+      ? 'stripes-smart-components.dateRange.missingStartDate'
+      : 'stripes-smart-components.dateRange.missingEndDate';
+
+    return (
+      <span data-test-missing-date={dateType}>
+        <FormattedMessage id={translationId} />
+      </span>
+    );
+  }
+
+  renderInvalidOrderError() {
+    return (
+      <span
+        className={styles.validationMessage}
+        data-test-wrong-dates-order
+      >
+        <FormattedMessage id="stripes-smart-components.dateRange.wrongOrder" />
+      </span>
+    );
+  }
+
+  getStartDateError() {
+    const {
+      startDateInvalid,
+      startDateMissing,
+    } = this.state.errors;
+
+    return (startDateInvalid && this.renderInvalidDateError(DATE_TYPES.START))
+      || (startDateMissing && this.renderMissingDateError(DATE_TYPES.START));
+  }
+
+  getEndDateError() {
+    const {
+      endDateInvalid,
+      endDateMissing,
+    } = this.state.errors;
+
+    return (endDateInvalid && this.renderInvalidDateError(DATE_TYPES.END))
+      || (endDateMissing && this.renderMissingDateError(DATE_TYPES.END));
+  }
+
+  render() {
+    const {
+      selectedValues: {
+        startDate,
+        endDate,
+      },
+      dateFormat,
+    } = this.props;
+
+    const { wrongDatesOrder } = this.state.errors;
+
+    const startDateError = this.getStartDateError();
+    const endDateError = this.getEndDateError();
+
+    return (
+      <>
+        <TextField
+          name={DATE_TYPES.START}
+          onBlur={this.onDateBlur}
+          label={<FormattedMessage id="stripes-smart-components.dateRange.from" />}
+          inputRef={this.startDateInput}
+          value={startDate}
+          placeholder={dateFormat}
+          error={startDateError || undefined}
+          data-test-date-input={DATE_TYPES.START}
+        />
+        <TextField
+          name={DATE_TYPES.END}
+          onBlur={this.onDateBlur}
+          label={<FormattedMessage id="stripes-smart-components.dateRange.to" />}
+          inputRef={this.endDateInput}
+          value={endDate}
+          placeholder={dateFormat}
+          error={endDateError || undefined}
+          data-test-date-input={DATE_TYPES.END}
+        />
+        {wrongDatesOrder && this.renderInvalidOrderError()}
+        <Button
+          onClick={this.onApplyButtonClick}
+          data-test-apply-button
+          marginBottom0
+        >
+          <FormattedMessage id="stripes-smart-components.dateRange.apply" />
+        </Button>
+      </>
+    );
+  }
+}

--- a/src/components/SearchAndSort/components/DateRangeFilter/date-types.js
+++ b/src/components/SearchAndSort/components/DateRangeFilter/date-types.js
@@ -1,0 +1,4 @@
+export default {
+  START: 'startDate',
+  END: 'endDate',
+};

--- a/src/components/SearchAndSort/components/DateRangeFilter/date-validations.js
+++ b/src/components/SearchAndSort/components/DateRangeFilter/date-validations.js
@@ -1,0 +1,42 @@
+import moment from 'moment';
+
+export const isDateValid = (date, dateFormat) => {
+  const momentDateWrapper = moment(date, dateFormat, true);
+
+  return momentDateWrapper.isValid();
+};
+
+export const validateDateRange = (dateRange, dateFormat) => {
+  const {
+    startDate,
+    endDate,
+  } = dateRange;
+
+  const startDateMomentWrapper = moment(startDate, dateFormat, true);
+  const endDateMomentWrapper = moment(endDate, dateFormat, true);
+
+  const startDateEmpty = startDate === '';
+  const endDateEmpty = endDate === '';
+  const bothDatesEntered = !startDateEmpty && !endDateEmpty;
+  const startDateMissing = !bothDatesEntered && !endDateEmpty;
+  const endDateMissing = !bothDatesEntered && !startDateEmpty;
+
+  const startDateInvalid = !startDateEmpty && !isDateValid(startDate, dateFormat);
+  const endDateInvalid = !endDateEmpty && !isDateValid(endDate, dateFormat);
+  const bothDatesValid = !startDateInvalid && !endDateInvalid;
+
+  const wrongDatesOrder = bothDatesValid && startDateMomentWrapper.isAfter(endDateMomentWrapper);
+
+  const dateRangeValid = bothDatesEntered && bothDatesValid && !wrongDatesOrder;
+
+  return {
+    dateRangeValid,
+    errors: {
+      startDateInvalid,
+      endDateInvalid,
+      endDateMissing,
+      startDateMissing,
+      wrongDatesOrder,
+    },
+  };
+};

--- a/src/components/SearchAndSort/components/DateRangeFilter/index.js
+++ b/src/components/SearchAndSort/components/DateRangeFilter/index.js
@@ -1,0 +1,1 @@
+export { default } from './DateRangeFilter';

--- a/src/components/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.js
+++ b/src/components/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.js
@@ -1,0 +1,47 @@
+/**
+ * CollapseFilterPaneButton
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { PaneHeaderIconButton, Tooltip } from '@folio/stripes-components';
+
+const CollapseFilterPaneButton = ({ onClick, filterCount }) => (
+  <FormattedMessage
+    id="stripes-smart-components.numberOfFilters"
+    values={{ count: filterCount }}
+  >
+    {appliedFiltersMessage => (
+      <FormattedMessage id="stripes-smart-components.showSearchPane">
+        {showSearchPaneMessage => (
+          <Tooltip
+            text={showSearchPaneMessage}
+            sub={filterCount ? appliedFiltersMessage : null}
+            id="expand-filter-pane-button-tooltip"
+          >
+            {({ ref, ariaIds }) => (
+              <PaneHeaderIconButton
+                ref={ref}
+                icon="caret-right"
+                iconSize="medium"
+                onClick={onClick}
+                badgeCount={filterCount || undefined}
+                aria-labelledby={ariaIds.text}
+                aria-describedby={ariaIds.sub}
+                data-test-expand-filter-pane-button
+              />
+            )}
+          </Tooltip>
+        )}
+      </FormattedMessage>
+    )}
+  </FormattedMessage>
+);
+
+CollapseFilterPaneButton.propTypes = {
+  filterCount: PropTypes.number,
+  onClick: PropTypes.func,
+};
+
+export default CollapseFilterPaneButton;

--- a/src/components/SearchAndSort/components/ExpandFilterPaneButton/index.js
+++ b/src/components/SearchAndSort/components/ExpandFilterPaneButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ExpandFilterPaneButton';

--- a/src/components/SearchAndSort/components/ExpandFilterPaneButton/readme.md
+++ b/src/components/SearchAndSort/components/ExpandFilterPaneButton/readme.md
@@ -1,0 +1,10 @@
+# ExpandFilterPaneButton
+This button is used to expand the filter pane. It should be placed in the `firstMenu` of the results pane.
+
+*Note:* It should be hidden when the filter pane is visible.
+
+## Props
+Name | Type | Description
+-- | -- | --
+onClick | func | Toggles the filter pane
+filterCount | number | Shows the current active filters count as a badge

--- a/src/components/SearchAndSort/components/MultiSelectionFilter/MultiSelectionFilter.js
+++ b/src/components/SearchAndSort/components/MultiSelectionFilter/MultiSelectionFilter.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { MultiSelection } from '@folio/stripes-components';
+
+export default class MultiSelectionFilter extends React.Component {
+  static propTypes = {
+    dataOptions: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.any,
+    })).isRequired,
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    selectedValues: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  static defaultProps = {
+    selectedValues: [],
+  }
+
+  onChangeHandler = (selectedDataOptions) => {
+    const {
+      name,
+      onChange,
+    } = this.props;
+
+    onChange({
+      name,
+      values: selectedDataOptions.map((option) => option.value),
+    });
+  };
+
+  getSelectedDataOptions() {
+    const {
+      selectedValues,
+      dataOptions,
+    } = this.props;
+
+    return selectedValues
+      .map((curValue) => dataOptions.find((curAvailableValue) => curAvailableValue.value === curValue));
+  }
+
+  render() {
+    return (
+      <MultiSelection
+        {...this.props}
+        value={this.getSelectedDataOptions()}
+        onChange={this.onChangeHandler}
+      />
+    );
+  }
+}

--- a/src/components/SearchAndSort/components/MultiSelectionFilter/index.js
+++ b/src/components/SearchAndSort/components/MultiSelectionFilter/index.js
@@ -1,0 +1,1 @@
+export { default } from './MultiSelectionFilter';

--- a/src/components/SearchAndSort/components/MultiSelectionFilter/tests/MultiSelectionFilter-test.js
+++ b/src/components/SearchAndSort/components/MultiSelectionFilter/tests/MultiSelectionFilter-test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mountWithContext } from '@folio/stripes-components/tests/helpers';
+import MultiSelectInteractor from '@folio/stripes-components/lib/MultiSelection/tests/interactor';
+
+import MultiSelectionFilter from '../MultiSelectionFilter';
+
+const multiSelectionFilter = new MultiSelectInteractor();
+
+const dataOptions = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  { value: 'it', label: 'Italian' },
+];
+
+describe('MultiSelectionFilter', () => {
+  const onChangeHandler = sinon.spy();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <MultiSelectionFilter
+        name="language"
+        dataOptions={dataOptions}
+        onChange={onChangeHandler}
+      />
+    );
+
+    onChangeHandler.resetHistory();
+  });
+
+  it('should not render any selected values by default', () => {
+    expect(multiSelectionFilter.values()).to.deep.equal([]);
+  });
+
+  describe('when there are selected values', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionFilter
+          name="language"
+          selectedValues={['en', 'fr', 'ge']}
+          dataOptions={dataOptions}
+          onChange={onChangeHandler}
+        />
+      );
+    });
+
+    it('should display selected values', () => {
+      expect(multiSelectionFilter.values(0).valLabel).to.equal('English');
+      expect(multiSelectionFilter.values(1).valLabel).to.equal('French');
+      expect(multiSelectionFilter.values(2).valLabel).to.equal('German');
+    });
+
+    describe('after click on a value delete button', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.values(0).clickRemoveButton();
+      });
+
+      it('should call onChange callback with filter name and rest values', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['fr', 'ge'],
+        }]);
+      });
+    });
+
+    describe('after click on selected option', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.options(1).clickOption();
+      });
+
+      it('should call onChange callback with filter name and rest values', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['en', 'ge']
+        }]);
+      });
+    });
+
+    describe('after click on unselected option', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.options(3).clickOption();
+      });
+
+      it('should pass filter name and all selected values to onChange callback', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['en', 'fr', 'ge', 'it'],
+        }]);
+      });
+    });
+  });
+});

--- a/src/components/SearchAndSort/components/NoResultsMessage/NoResultsMessage.css
+++ b/src/components/SearchAndSort/components/NoResultsMessage/NoResultsMessage.css
@@ -1,0 +1,38 @@
+/**
+ * No Results Message
+ */
+
+@import '@folio/stripes-components/lib/variables';
+
+/* Empty Message */
+.noResultsMessage {
+  padding: 15px;
+  color: var(--color-text-p2);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-fill);
+  flex-direction: column;
+}
+
+.noResultsMessage,
+.noResultsMessageLabelWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.noResultsMessageLabelWrap {
+  font-size: var(--font-size-large);
+}
+
+.noResultsMessageIcon,
+.noResultsMessageLabel {
+  margin: 0 4px;
+}
+
+.noResultsMessageButton {
+  margin-top: 15px;
+}

--- a/src/components/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
+++ b/src/components/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
@@ -1,0 +1,65 @@
+/**
+ * No Results Message
+ *
+ * Renders a no results message based on a users inputs
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Button, Icon } from '@folio/stripes-components';
+import css from './NoResultsMessage.css';
+
+const NoResultsMessage = ({ source, searchTerm, filterPaneIsVisible, toggleFilterPane, notLoadedMessage }) => {
+  const failure = source.failure();
+
+  let icon = 'search';
+  let label = <FormattedMessage id="stripes-smart-components.sas.noResults.default" values={{ searchTerm }} />;
+
+  // No search term entered or filters selected
+  if (!source.loaded()) {
+    icon = filterPaneIsVisible ? 'arrow-left' : null;
+    label = notLoadedMessage || <FormattedMessage id="stripes-smart-components.sas.noResults.noTerms" />;
+  }
+
+  // Filters selected and no search term but no results
+  if (source.loaded() && !searchTerm) {
+    icon = 'search';
+    label = <FormattedMessage id="stripes-smart-components.sas.noResults.noResults" />;
+  }
+
+  // Loading results
+  if (source.pending()) {
+    icon = 'spinner-ellipsis';
+    label = <FormattedMessage id="stripes-smart-components.sas.noResults.loading" />;
+  }
+
+  // Request failure
+  if (failure) {
+    icon = 'exclamation-circle';
+    label = source.failureMessage();
+  }
+
+  return (
+    <div className={css.noResultsMessage}>
+      <div className={css.noResultsMessageLabelWrap}>
+        {icon && <Icon iconRootClass={css.noResultsMessageIcon} icon={icon} />}
+        <span className={css.noResultsMessageLabel}>{label}</span>
+      </div>
+      {/* If the filter pane is closed we show a button that toggles filter pane */}
+      {!filterPaneIsVisible && (
+        <Button marginBottom0 buttonClass={css.noResultsMessageButton} onClick={toggleFilterPane}>Show filters</Button>
+      )}
+    </div>
+  );
+};
+
+NoResultsMessage.propTypes = {
+  filterPaneIsVisible: PropTypes.bool.isRequired,
+  notLoadedMessage: PropTypes.string,
+  searchTerm: PropTypes.string.isRequired,
+  source: PropTypes.object.isRequired,
+  toggleFilterPane: PropTypes.func.isRequired,
+};
+
+export default NoResultsMessage;

--- a/src/components/SearchAndSort/components/NoResultsMessage/index.js
+++ b/src/components/SearchAndSort/components/NoResultsMessage/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoResultsMessage';

--- a/src/components/SearchAndSort/components/ResetButton/ResetButton.css
+++ b/src/components/SearchAndSort/components/ResetButton/ResetButton.css
@@ -1,0 +1,7 @@
+/**
+ * Reset Button
+ */
+
+.resetButtonRoot .button {
+  padding: 0 6px 0 3px;
+}

--- a/src/components/SearchAndSort/components/ResetButton/ResetButton.js
+++ b/src/components/SearchAndSort/components/ResetButton/ResetButton.js
@@ -1,0 +1,48 @@
+/**
+ * Reset Button
+ *
+ * A delayed disapearable button
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames'; /* eslint-disable-line import/no-extraneous-dependencies */
+import { Button, Icon } from '@folio/stripes-components';
+import css from './ResetButton.css';
+
+export default class ResetButton extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    label: PropTypes.node,
+    onClick: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const {
+      id,
+      label,
+      className,
+      disabled,
+      onClick,
+      ...restProps
+    } = this.props;
+    return (
+      <div className={css.resetButtonRoot}>
+        <Button
+          buttonStyle="none"
+          id={id}
+          onClick={onClick}
+          disabled={disabled}
+          buttonClass={classnames(css.button, className)}
+          {...restProps}
+        >
+          <Icon size="small" icon="times-circle-solid">
+            {label}
+          </Icon>
+        </Button>
+      </div>
+    );
+  }
+}

--- a/src/components/SearchAndSort/components/ResetButton/index.js
+++ b/src/components/SearchAndSort/components/ResetButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResetButton';

--- a/src/components/SearchAndSort/components/SearchButton/SearchButton.css
+++ b/src/components/SearchAndSort/components/SearchButton/SearchButton.css
@@ -1,0 +1,30 @@
+@import '@folio/stripes-components/lib/variables';
+
+.button {
+  composes: boxOffsetSmall from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";
+  margin: 0;
+  padding: 0;
+  font-size: var(--font-size-medium);
+  color: var(--color-text-p2);
+}
+
+.badge {
+  margin: 0 0 0 0.2rem;
+}
+
+[dir="rtl"] .badge {
+  margin: 0 0.2rem 0 0;
+}
+
+.arrow {
+  width: 0.7rem;
+  opacity: 1;
+  transition: opacity 300ms ease-out;
+
+  &.hidden {
+    opacity: 0;
+    width: 0;
+    overflow: hidden;
+    transition: opacity 300ms ease-out;
+  }
+}

--- a/src/components/SearchAndSort/components/SearchButton/SearchButton.js
+++ b/src/components/SearchAndSort/components/SearchButton/SearchButton.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import {
+  Badge,
+  Button,
+  Icon,
+  Layout,
+} from '@folio/stripes-components';
+
+import css from './SearchButton.css';
+
+const visiblePanelIcons = ['chevron-left', 'search'];
+const hiddenPanelIcons = ['search', 'chevron-right'];
+const icons = ['chevron-left', 'search', 'badge', 'chevron-right'];
+
+export default class SearchButton extends Component {
+  static propTypes = {
+    ariaLabel: PropTypes.string,
+    badge: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    onClick: PropTypes.func.isRequired,
+    visible: PropTypes.bool.isRequired,
+  }
+
+  renderIcons = (badge) => {
+    const visibleIcons = this.props.visible ? visiblePanelIcons : hiddenPanelIcons;
+
+    return icons.map((iconName) => {
+      if (iconName === 'badge') {
+        return (badge &&
+          <Badge key={iconName} className={css.badge}>
+            {badge}
+          </Badge>
+        );
+      }
+
+      return (
+        <Icon
+          iconRootClass={classnames(
+            css.icon,
+            { [css.hidden]: !visibleIcons.includes(iconName) },
+            { [css.arrow]: iconName.includes('chevron') },
+          )}
+          size="medium"
+          icon={iconName}
+          key={iconName}
+        />
+      );
+    });
+  }
+
+  render() {
+    const {
+      ariaLabel,
+      badge,
+      onClick,
+      visible,
+      ...rest
+    } = this.props;
+
+    const buttonClass = classnames(
+      css.button,
+      { [css.hasBadge]: typeof badge !== 'undefined' },
+    );
+
+    const iconWrapperClass = classnames(
+      'display-flex',
+      'flex-align-items-center',
+      css.inner,
+      { [css.moved]: !visible },
+    );
+
+    return (
+      <Button
+        buttonStyle="none"
+        buttonClass={buttonClass}
+        aria-label={ariaLabel}
+        onClick={onClick}
+        {...rest}
+      >
+        <Layout className={iconWrapperClass}>
+          {this.renderIcons(badge)}
+        </Layout>
+      </Button>
+    );
+  }
+}

--- a/src/components/SearchAndSort/components/SearchButton/index.js
+++ b/src/components/SearchAndSort/components/SearchButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchButton';

--- a/src/components/SearchAndSort/components/index.js
+++ b/src/components/SearchAndSort/components/index.js
@@ -1,0 +1,8 @@
+export { default as CheckboxFilter } from './CheckboxFilter';
+export { default as CollapseFilterPaneButton } from './CollapseFilterPaneButton';
+export { default as DateRangeFilter } from './DateRangeFilter';
+export { default as ExpandFilterPaneButton } from './ExpandFilterPaneButton';
+export { default as MultiSelectionFilter } from './MultiSelectionFilter';
+export { default as NoResultsMessage } from './NoResultsMessage';
+export { default as ResetButton } from './ResetButton';
+export { default as SearchButton } from './SearchButton';

--- a/src/components/SearchAndSort/index.js
+++ b/src/components/SearchAndSort/index.js
@@ -1,0 +1,3 @@
+export { default } from './SearchAndSort';
+export { default as makeQueryFunction } from './makeQueryFunction';
+export { default as SearchAndSortQuery } from './SearchAndSortQuery';

--- a/src/components/SearchAndSort/makeQueryFunction.js
+++ b/src/components/SearchAndSort/makeQueryFunction.js
@@ -1,0 +1,99 @@
+import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
+import { filters2cql } from '@folio/stripes-components/lib/FilterGroups';
+import escapeCqlValue from '@folio/stripes-util/lib/escapeCqlValue';
+import { get } from 'lodash';
+
+import { removeNsKeys } from './nsQueryFunctions';
+
+// return a function that returns a string, or null, which stripes-connect
+// will use to construct a resource query. it will accept four params:
+//
+//     * An object containing the UI URL's query parameters (as accessed by ?{name}).
+//     * An object containing the UI URL's path components (as accessed by :{name}).
+//     * An object containing the component's resources' data (as accessed by %{name}).
+//     * A logger object.
+//
+// @findAll string: CQL query to retrieve all records when there is a sort-clause but no CQL query
+// @queryTemplate string|function: CQL query to interpolate or function which will return CQL as a string
+// @sortMap object: map from sort-keys to the CQL fields they match
+// @filterConfig array: list of filter objects with keys label, name, cql, values
+// @failOnCondition int:
+//      0: do not fail even if query and filters and empty
+//      1: fail if query is empty, whatever the filter state
+//      2: fail if both query and filters and empty.
+//     For compatibility, false and true may be used for 0 and 1 respectively.
+// @nsParams object|string: namespace keys
+// @escape boolean whether to escape quote and backslash values in the query (default: true)
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, escape = true) {
+  return (queryParams, pathComponents, resourceValues, logger) => {
+    const resourceQuery = removeNsKeys(resourceValues.query, nsParams);
+    const nsQueryParams = removeNsKeys(queryParams, nsParams);
+    const { qindex, filters, query, sort } = resourceQuery || {};
+
+    if ((query === undefined || query === '') &&
+        (failOnCondition === 1 || failOnCondition === true)) {
+      return null;
+    }
+    if ((query === undefined || query === '') &&
+        (filters === undefined || filters === '') &&
+        (failOnCondition === 2)) {
+      return null;
+    }
+
+    const escapeFx = escape ? escapeCqlValue : (s) => (s);
+
+    let cql;
+    if (query && qindex) {
+      const t = qindex.split('/', 2);
+      if (t.length === 1) {
+        cql = `${qindex}="${escapeFx(query)}*"`;
+      } else {
+        cql = `${t[0]} =/${t[1]} "${escapeFx(query)}*"`;
+      }
+    } else if (query) {
+      const escapedQuery = { ...resourceQuery, ...{ query: escapeFx(get(resourceQuery, 'query', '')) } };
+      cql = (typeof queryTemplate === 'function')
+        ? queryTemplate(nsQueryParams, pathComponents, { query: escapedQuery })
+        : compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: escapedQuery });
+
+      if (cql === null) {
+        // Some part of the template requires something that we don't have.
+        return null;
+      }
+    }
+
+
+    const filterCql = filters2cql(filterConfig, filters);
+    if (filterCql) {
+      if (cql) {
+        cql = `(${cql}) and ${filterCql}`;
+      } else {
+        cql = filterCql;
+      }
+    }
+
+    if (sort) {
+      const sortIndexes = sort.split(',').map((sort1) => {
+        let reverse = false;
+        if (sort1.startsWith('-')) {
+          sort1 = sort1.substr(1); // eslint-disable-line no-param-reassign
+          reverse = true;
+        }
+        let sortIndex = sortMap[sort1] || sort1;
+        if (reverse) {
+          sortIndex = sortIndex.replace(' ', '/sort.descending ') + '/sort.descending';
+        }
+        return sortIndex;
+      });
+
+      if (cql === undefined) cql = findAll;
+      cql = `(${cql}) sortby ${sortIndexes.join(' ')}`;
+    }
+
+    logger.log('mquery', `query='${query}' filters='${filters}' sort='${sort}' -> ${cql}`);
+
+    return cql;
+  };
+}
+
+export default makeQueryFunction;

--- a/src/components/SearchAndSort/nsQueryFunctions.js
+++ b/src/components/SearchAndSort/nsQueryFunctions.js
@@ -1,0 +1,46 @@
+import { isString, isObject, mapKeys, mapValues, transform } from 'lodash';
+
+// the list of allowed parameters to which the namespace will be added
+const PARAM_WHITELIST = { filters: 1, query: 1, sort: 1, qindex: 1 };
+
+export function getNsKey(key, params) {
+  if (!params || !PARAM_WHITELIST[key]) return key;
+  return (isString(params)) ? `${params}.${key}` : (params[key] || key);
+}
+
+// Adds namespace / prefix to keys in whitelist for given values object
+//
+// example:
+// values = { query: "test", filters: 'active', userId: 1 }, params = 'users'
+// result:
+// { "users.query" : "test", "users.filters": "active", userId: 1 }
+export function mapNsKeys(values, params) {
+  if (!params) return values;
+  return mapKeys(values, (value, key) => getNsKey(key, params));
+}
+
+// Removes namespace / prefix from keys for given values object
+//
+// example:
+// values = { "users.query" : "test", "users.filters": "active" }, params = 'users'
+// result:
+// { query: "test", filters: 'active' }
+export function removeNsKeys(values, params) {
+  if (!params) return values;
+
+  if (isObject(params)) {
+    return mapValues(params, value => values[value]);
+  }
+
+  if (isString(params)) {
+    const prefix = new RegExp(`^${params}\\.`, 'i');
+    return transform(values, (result, value, key) => {
+      if (key.match(prefix)) {
+        result[key.replace(prefix, '')] = value;
+      }
+      return result;
+    }, {});
+  }
+
+  return values;
+}

--- a/src/components/SearchAndSort/parameterizing-makeQueryFunction.md
+++ b/src/components/SearchAndSort/parameterizing-makeQueryFunction.md
@@ -1,0 +1,106 @@
+# Discussion point: parameterizing `makeQueryFunction`
+
+<!-- md2toc -l 2 parameterizing-makeQueryFunction.md -->
+* [Introduction](#introduction)
+    * [Motivation](#motivation)
+    * [Principles](#principles)
+* [Proposal](#proposal)
+* [Examples](#examples)
+    * [Code](#code)
+    * [URLs](#urls)
+* [Implications](#implications)
+
+
+## Introduction
+
+### Motivation
+
+UNAM (the National Autonomous University of Mexico) are adding functionality to the Users app to allow an administrator, once a user has been selected, to search within that user's fees and fines. To achieve this, they want to use the `<SearchAndSort>` high-level utility component and the associated function `makeQueryFunction`. However, this does not work because the URL query parameters that it uses -- `query`, `filters`, `sort` -- have already been set by the User app's own use of `<SearchAndSort>`.
+
+How can the UNAM team provide searching at this nested level within an app?
+
+
+### Principles
+
+It is widely agreed that utilities like `<SearchAndSort>` and `makeQueryFunction` should be as dumb as possible, not making assumptions about what parts of the URL query namespace they can use. Instead, callers of `makeQueryFunction` should specify at the time they call it which URL parameters it should use. (The same is true of `<SearchAndSort>`, but for simplicity this document will concentrate on `makeQueryFunction`.)
+
+
+## Proposal
+
+The simplest way to parameterize `makeQueryFunction` is to pass in a set of parameter names to use. As a short-cut, it should be possible simply to pass in a prefix, used to namespace the standard parameter names. Finally, when no parameter names or prefix are provided, the present behaviour should be retained, and the standard set of parameter names used. This will provide both backwards-compatibility in the API and a convenient shorthand for the common case of using this facility at the top-level of a UI module.
+
+I propose a single additional argument, `params`, which may be either a string which is used as a prefix, or an object whose keys are the standard parameters and whose corresponding values are the parameters to use in their roles.
+
+
+## Examples
+
+### Code
+
+The Users app presently uses `makeQueryFunction` at the top level to manage searching and sorting users. The function that it returns is installed as `manifest.records.GET.params.query`, and the invocation is as follows:
+
+```
+	makeQueryFunction(
+	  'cql.allRecords=1',
+	  '(username="%{query.query}*" or personal.firstName="%{query.query}*" or personal.lastName="%{query.query}*" or personal.email="%{query.query}*" or barcode="%{query.query}*" or id="%{query.query}*" or externalSystemId="%{query.query}*")',
+	  {
+	    'Active': 'active',
+	    'Name': 'personal.lastName personal.firstName',
+	    'Patron group': 'patronGroup.group',
+	    'Username': 'username',
+	    'Barcode': 'barcode',
+	    'Email': 'personal.email',
+	  },
+	  filterConfig,
+	  2,
+	)
+```
+The parameters are as follows:
+* Query to use for finding all records when no query-string is specified in the UI.
+* Query string template for when the query has been specified in the UI.
+* Sort-map, from column-header names to CQL sort-field names.
+* Filter configuration (see [**FilterGroups: Filter configuration**](../lib/FilterGroups/readme.md#filter-configuration)).
+* A specification that query-generation should fail when both the UI query and the filters are unspecified.
+
+To this, a sixth argument may be added, which might take any of the following values:
+
+* `null`: use the standard parameter as is presently the case.
+* `'users': prefix the names of the standard parameters with `users.`, so that they become `users.query`, `users.filters` and `users.sort`.
+* `{ query: 'users.query', filters: 'users.filters', sort: 'users.sort' }`: equivalent to the prefix, but specified explicitly.
+* `{ query: 'uq', filters: 'uf', sort: 'us' }`: use the more terser parameter names `uq`, `uf` and `us` in place of the standard parameters.
+
+Assuming that no such argument was provided in the Users app's top-level invocation of `makeQueryFunction`, the nested component that provides searching and sorting of fees and fines might invoke along these lines for its own manifest:
+
+```
+	makeQueryFunction(
+	  'cql.allRecords=1',
+	  'feeFineType="%{query.query}*"',
+	  {
+	    'Amount': 'defaultAmount',
+	    'VAT%': 'taxVat',
+	  },
+	  filterConfig,
+	  0,
+	  'fees'
+	)
+```
+
+### URLs
+
+The setup outlined above would cause the parameter `fees.query`, `fees.filters` and `fees.sort` to be used for generating the relevant queries. These could co-exist in the URL along with the corresponding parameters as used by the top-level application, yielding URLs such as
+
+	http://demo.folio.org/users/view/123/feesfines?query=smith&filters=active.Active&fees.query=overdue
+
+It would be a matter for application designers to decide when to retain all of a URL's query parameters, and when to discard some: for example, in some situations it may be desirable when generating the URL for a fees-and-fines page to discard the information about the user search. In this case, the URL would simply be:
+
+	http://demo.folio.org/users/view/123/feesfines?fees.query=overdue
+
+(The information about which user the listed fees and fines are for is held in the URL path, not a parameter: it is the user-ID `123`.)
+
+
+## Implications
+
+A similar configurability facility would also need to be added to the `<SearchAndSort>` component, which sets the URL query parameters that `makeQueryFunction` reads. The principles are the same as outlined here.
+
+This issue is not limited to `<SearchAndSort>` and `makeQueryFunction`, but also bleeds over into `<FilterGroups>` and any other components and utility functions in stripes-components that have unfettered access to the URL.
+
+

--- a/src/components/SearchAndSort/parseFilters.js
+++ b/src/components/SearchAndSort/parseFilters.js
@@ -1,0 +1,30 @@
+// parseFilters parses a string like
+//    departments.123,coursetypes.abc,coursetypes.def
+// into an object mapping filter-name to lists of values;
+// and deparseFilters performs the opposite operation
+
+export function parseFilters(filters) {
+  if (!filters) return {};
+  const byName = {};
+
+  filters.split(',').forEach(string => {
+    const [name, value] = string.split('.');
+    if (!byName[name]) byName[name] = [];
+    byName[name].push(value);
+  });
+
+  return byName;
+}
+
+export function deparseFilters(byName) {
+  const a = [];
+
+  Object.keys(byName).sort().forEach(name => {
+    const values = byName[name];
+    values.forEach(value => {
+      a.push(`${name}.${value}`);
+    });
+  });
+
+  return a.join(',');
+}

--- a/src/components/SearchAndSort/readme.md
+++ b/src/components/SearchAndSort/readme.md
@@ -1,0 +1,112 @@
+# SearchAndSort
+
+Generic component providing the heart of search-and-sort modules
+
+<!-- md2toc -l 2 readme.md -->
+* [Description](#description)
+    * [Properties](#properties)
+* [`makeQueryFunction`](#makequeryfunction)
+
+## Description
+
+Many Stripes application modules are primarily to do with searching, sorting and browsing sets of records of some kind, and viewing their detailed information, editing them, creating new records, etc. Examples of such modules include ui-users, ui-inventory and ui-requests. Such modules can be created quickly and easily by having their `render` method simply invoke `<SearchAndSort>` with appropriate configuration. It is then the application's responsibility to provide components that view records of the relevant type in detail, that edit them, etc.
+
+### Properties
+
+Name | type | description
+--- | --- | ---
+moduleName | string | The machine-readable name of the module for which `<SearchAndSort>` is being invoked, to be used in generating HTML IDs, etc. This is usually the last component of `packageInfo.name`.
+moduleTitle | string | The human-readable name of the module, to be used in visible titles, etc. This is usually `packageInfo.stripes.displayName`.
+objectName | string | The machine-readable name of the kind of record that is being managed -- often the singular form of the `moduleName` (e.g. "user" for "users"). This is used both in HTML IDs and, in capitalised form, in some human-readable captions.
+baseRoute | string | The base route at which the module is visible. Should be set to `packageInfo.stripes.route`.
+searchableIndexes | array of structures | Each structure in the array represents an index which the application can search in. The presence of this property causes a dropdown to appear before the query box offering the choice of indexes. Each structure must contain a human-readable string called `label`, a corresponding CQL index-name called `value` (which may be blank for a "search all indexes" entry) and optionally a boolean called `disabled`, which should be set for indexes which should be displayed greyed out and unavailable for selection.
+searchableIndexesPlaceholder | string | If this is provided and is a string, then it appears as an unselectable (permanently disabled) first entry in the index-selection dropdown. If it is provided and is `null` then no placeholder is added. For backwards compatibility, if it completely absent then a default placeholder string is used.
+selectedIndex | string | When `searchableIndexes` is provided, this must also be supplied, its value matching one of those in the provided array.
+onChangeIndex | function | If provided, this function is invoked, and passed an event structure, when the user changes which index is selected.
+maxSortKeys | number | If provided, specifies that maximum number of sort-keys that should be remembered for "stable sorting". Defaults to 2 if not specified.
+sortableColumns | array | If provided, specifies the columns that can be sorted.
+filterConfig | array of structures | Configuration for the module's filters, as documented [in the `<FilterGroups>` readme](https://github.com/folio-org/stripes-components/tree/master/lib/FilterGroups#filter-configuration).
+initialFilters | string | The initial state of the filters when the application started up, used when resetting to the initial state. Takes the same form as the `filters` part of the URL: a comma-separated list of `group`.`name` filters that are selected.
+disableFilters | object whose keys are filter-group names | In the display of filter groups, those that are named in this object are greyed out and cannot be selected.
+filterChangeCallback | function | If provided, this function is invoked when the user changes a filter. It is passed the new set of filters, in the form of an object whose keys are the `group`.`name` specifiers of each selected filter.
+onFilterChange | function | Callback to be called after filter value is changed. Gets filter name and filter values in a form of an object `{ name: <String>, values: <Array> }`.
+renderFilters | function | Renders a set of filters. Gets onChange callback to be called after filter value change.
+renderNavigation | function | Renders a component at the top of the first section (filters) to be used as navigation. Default `noop`.
+initialResultCount | number | The number of records to fetch when a new search is executed (including the null search that is run when the module starts).
+resultCountIncrement | number | The amount by which to increase the number of records when scrolling close to the bottom of the loaded list.
+viewRecordComponent | component | A React component that displays a record of the appropriate type in full view. This is invoked with a specific set of properties that ought also to be documented, but for now, see the example of [`<ViewUser>` in ui-users](https://github.com/folio-org/ui-users/blob/master/ViewUser.js).
+viewRecordPathById | function | A function that takes an id and returns a path to link brief records to. Used in lieu of `viewRecordComponent`
+createRecordPath | string | Path to link the "New" button to rather than use `editRecordComponent`.
+editRecordComponent | component | A React component that displays an editing form for a record of the appropriate type, and which can also be used for creating new records. This is invoked with a specific set of properties that ought also to be documented, but for now, see the example of [`<UserForm>` in ui-users](https://github.com/folio-org/ui-users/blob/master/UserForm.js).
+newRecordInitialValues | object whose keys are field-names | Values to set into the form when creating a new record.
+visibleColumns | array of fieldnames | As for [`<MultiColumnList>`](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/readme.md)
+columnWidths | object whose names are field captions | As for [`<MultiColumnList>`](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/readme.md)
+columnMapping | object whose names are field captions | As for [`<MultiColumnList>`](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/readme.md)
+resultsFormatter | object mapping field-names to functions | As for [`<MultiColumnList>`](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/readme.md)
+onSelectRow | func | Optional function to override the default action when selecting a row (which displays the full record). May be used, for example, when running one module embedded in another, as when ui-checkin embeds an instance of ui-users to select the user for whom items are being checked out.
+massageNewRecord | func | If provided, this function is passed newly submitted records and may massage them in whatever way it wishes before they are persisted to the back-end. May be used to perform lookups, expand abbreviations, etc.
+onCreate | func | A function which is passed the (possibly massaged) record, and must persist it to the back-end. In most cases this will be a one-liner, but some modules (e.g. ui-users) have more complex requirements.
+finishedResourceName | string | Newly created records are displayed as soon as they are created. Usually that is as soon as the record itself exists, but in some cases it is not until some other operation has completed -- for example, new user records are not ready to be displayed until their permissions have been added. In such situations, this property may be set to the name of the resource which must have completed its operations before the record is ready.
+viewRecordPerms | string | A comma-separated list of the permissions required in order to view a full record.
+newRecordPerms | string | A comma-separated list of the permissions required in order to create a new record.
+disableRecordCreation | bool | If true, new record cannot be created. This is appropriate when one application is running embedded in another.
+parentResources | shape | The parent component's stripes-connect `resources` property, used to access the records of the relevant type. Must contain at least `records`, `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
+parentMutator | shape | The parent component's stripes-connect `mutator` property. Must contain at least `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
+nsParams | object or string | An object or string used to namespace search and sort parameters. More information can be found [here](https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md)
+notLoadedMessage | string | A message to show the user before a search has been submitted. Defaults to "Choose a filter or enter search query to show results".
+getHelperResourcePath | func | An optional function which can be used to return helper's resource path dynamically.
+getHelperComponent | func | An optional function which can be used to return connected helper component implementation.
+title | string/element | An optional property to specify title of results pane. By default module display name is used.
+hasNewButton | boolean | An optional property to specify appearance Of `New` button of results pane. By default pane displays with `New` button.
+basePath | string | An optional string to customize the path which should be used after performing search.
+
+See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
+
+## `makeQueryFunction`
+
+Invoked as:
+
+	makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition)
+
+Makes and returns a function, suitable to be used as the `query` param of a stripes-connect resource configuration. The function is itself configured by five parameters, which will vary depending on the module that is using it, and will use these to determine how to interpret the query, filters and sort-specification in the application state. It is generally used as follows:
+```
+static manifest = Object.freeze({
+  items: {
+    type: 'okapi',
+    records: 'items',
+    path: 'item-storage/items',
+    params: {
+      query: makeQueryFunction(
+        'cql.allRecords=1',
+        'materialType="${query}" or barcode="${query}*" or title="${query}*"',
+        { 'Material Type': 'materialType' },
+        filterConfig,
+        2
+      ),
+    },
+    staticFallback: { params: {} },
+  },
+});
+```
+
+The five parameters are:
+
+* `findAll` -- a CQL string that can be used to find all records, for situations where no query or filters are specified and the application wants all records to be listed.
+* `queryTemplate` -- a CQL string into which the query and other data can be substituted, using the same syntax as [path substitution in stripes-connect](https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution): for example, `?{query}` interpolates the `query` parameter from the URL.
+* `sortMap` -- an object mapping the names of columns in the display to the CQL sort-specifiers that they should invoke when clicked on.
+* `filterConfig` -- the configuration of the application's filter as passed to [the `<FilterGroups>` component](../lib/FilterGroups/readme.md#filter-configuration).
+* `failOnCondition` -- an optional indicator of how to behave when no query and/or filters are provided. Can take the following values:
+  * `0`: do not fail even if query and filters and empty
+  * `1`: fail if query is empty, whatever the filter state
+  * `2`: fail if both query and filters and empty.
+
+  For backwards compatibility, `false` (or omitting the argument altogether) is equivalent to `0` , and `true` is equivalent to `1`.
+
+  ## Components for filtering
+
+  Please, pay attention, there is a set of components to be used for filtering inside SearchAndSort component. Each component represents a wrapper on existing form element component e.g. MultiSelect or renders a set of elements working like one filter e.g. CheckboxFilter. After change returns data in format: {name: <String>, values: <ArrayOfObjects>}, where name -- is a filter name and values -- filter values.
+
+
+## Implementing filters
+
+See the separate document [_Building filters for your Stripes app_](building-filters.md).

--- a/src/components/SearchField/SearchField.css
+++ b/src/components/SearchField/SearchField.css
@@ -1,0 +1,25 @@
+/**
+ * SearchField
+ */
+
+@import "@folio/stripes-components/lib/variables.css";
+
+/**
+ * Has searchable indexes
+ */
+
+/* Select field */
+.searchFieldWrap .select {
+  /* To make sure it's position is above
+  so the focus style isn't hidden by the input */
+  margin-bottom: -1px;
+
+  &:focus {
+    z-index: 5;
+  }
+}
+
+/* Color search icon on focus */
+.searchFieldWrap .isFocused svg.searchIcon {
+  fill: var(--primary);
+}

--- a/src/components/SearchField/SearchField.js
+++ b/src/components/SearchField/SearchField.js
@@ -1,0 +1,152 @@
+/**
+ * SearchField
+ *
+ * A universal search field component
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useIntl } from 'react-intl';
+
+import TextField from '@folio/stripes-components/lib/TextField';
+import Select from '@folio/stripes-components/lib/Select';
+import TextFieldIcon from '@folio/stripes-components/lib/TextField/TextFieldIcon';
+
+import ElasticQueryField from '../ElasticQueryField';
+import css from './SearchField.css';
+
+// Accepts the same props as TextField
+const propTypes = {
+  ariaLabel: PropTypes.string,
+  className: PropTypes.string,
+  clearSearchId: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  inputClass: PropTypes.string,
+  inputRef: PropTypes.object,
+  isAdvancedSearch: PropTypes.bool,
+  loading: PropTypes.bool,
+  onChange: PropTypes.func,
+  onChangeIndex: PropTypes.func,
+  onClear: PropTypes.func,
+  placeholder: PropTypes.string,
+  searchableIndexes: PropTypes.arrayOf(PropTypes.shape({
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    label: PropTypes.string,
+    placeholder: PropTypes.string,
+    value: PropTypes.string,
+  })),
+  searchableIndexesPlaceholder: PropTypes.string,
+  searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  selectedIndex: PropTypes.string,
+  value: PropTypes.string,
+};
+
+const SearchField = (props) => {
+  const {
+    className,
+    placeholder,
+    id,
+    ariaLabel,
+    value,
+    onChange,
+    onClear,
+    loading,
+    clearSearchId,
+    searchableIndexes,
+    onChangeIndex,
+    selectedIndex,
+    searchableIndexesPlaceholder,
+    inputClass,
+    disabled,
+    isAdvancedSearch,
+    searchButtonRef,
+    ...rest
+  } = props;
+
+  /**
+   * Search field has searchable indexes dropdown
+   */
+  let searchableIndexesDropdown;
+  const hasSearchableIndexes = Array.isArray(searchableIndexes);
+  const intl = useIntl();
+
+  if (hasSearchableIndexes) {
+    const indexLabel = intl.formatMessage({ id: 'stripes-components.searchFieldIndex' });
+
+    searchableIndexesDropdown = (
+      <Select
+        aria-label={indexLabel}
+        dataOptions={searchableIndexes}
+        disabled={loading}
+        id={`${id}-qindex`}
+        marginBottom0
+        onChange={onChangeIndex}
+        placeholder={searchableIndexesPlaceholder}
+        selectClass={css.select}
+        value={selectedIndex}
+      />
+    );
+  }
+
+  // Wrapper styles
+  const rootStyles = classNames(
+    css.searchFieldWrap,
+    { [css.hasSearchableIndexes]: hasSearchableIndexes },
+    className,
+  );
+
+  // Search icon
+  const searchIcon = (<TextFieldIcon iconClassName={css.searchIcon} icon="search" />);
+
+  // Placeholder
+  let inputPlaceholder = placeholder;
+  if (!placeholder && hasSearchableIndexes && selectedIndex) {
+    const selectedIndexConfig = searchableIndexes.find(index => index.value === selectedIndex) || {};
+    inputPlaceholder = selectedIndexConfig.placeholder || '';
+  }
+
+  return (
+    <div className={rootStyles}>
+      {searchableIndexesDropdown}
+      {isAdvancedSearch
+        ? (
+          <ElasticQueryField
+            onChange={onChange}
+            searchButtonRef={searchButtonRef}
+            value={value}
+          />
+        )
+        : (
+          <TextField
+            {...rest}
+            aria-label={rest['aria-label'] || ariaLabel}
+            clearFieldId={clearSearchId}
+            disabled={disabled}
+            focusedClass={css.isFocused}
+            id={id}
+            hasClearIcon={typeof onClear === 'function' && loading !== true}
+            inputClass={classNames(css.input, inputClass)}
+            loading={loading}
+            onChange={onChange}
+            onClearField={onClear}
+            placeholder={inputPlaceholder}
+            startControl={!hasSearchableIndexes ? searchIcon : null}
+            type="search"
+            value={value || ''}
+            readOnly={loading || rest.readOnly}
+          />
+        )
+      }
+    </div>
+  );
+};
+
+SearchField.propTypes = propTypes;
+SearchField.defaultProps = {
+  loading: false,
+};
+
+export default SearchField;

--- a/src/components/SearchField/index.js
+++ b/src/components/SearchField/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchField';

--- a/src/components/SearchField/readme.md
+++ b/src/components/SearchField/readme.md
@@ -1,0 +1,67 @@
+# SearchField
+
+Universal search field component.
+
+## Basic Usage
+
+```
+  import { SearchField } from '@folio/stripes/components';
+
+  <SearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+  />
+```
+
+## Usage with searchable indexes
+The component supports adding an array of searchable indexes which adds a select field to the component.
+
+```
+  import SearchField from '@folio/stripes/components';
+
+  const searchableIndexes = [
+    { label: 'ID', value: 'id' },
+    { label: 'Title', value: 'title', placeholder: 'Search by Title' },
+    { label: 'Identifier', value: 'identifier', localOnly: true },
+  ];
+
+  <SearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+
+    searchableIndexes={searchableIndexes}
+    onChangeIndex={() => ...}
+    selectedIndex={...}
+    searchableIndexesPlaceholder="Search for these fields.."
+  />
+```
+
+## Props
+This component supports the same props as the TextField component among other props.
+
+Name | type | Description
+-- | -- | --
+placeholder | string | Adds a placeholder to the search input field
+id | string | Adds an ID to the input field
+className | string | Adds a className to the root element
+inputClass | string | Adds a className to the input
+aria-label | string | Adds an aria label to the input field. Camel-case `ariaLabel` is also accepted.
+value | string | The value of the input field
+loading | boolean | Adds a loading state to icon (on fetch etc.)
+onChange | function | On change handler for the input field
+onClear | function | On clear search field callback
+clearSearchId | string | Adds id to the clear search icon
+
+### With searchable indexes
+Additional props for adding searchable indexes/fields.
+
+Name | type | Description
+-- | -- | --
+searchableIndexes | array of objects | Adds a list of searchable indexes/fields
+selectedIndex | string | Currently selected index
+onChangeIndex | function | On change handler for when changing index
+searchableIndexesPlaceholder | string | Control the placeholder of the select field

--- a/src/components/SearchField/readme.md
+++ b/src/components/SearchField/readme.md
@@ -15,6 +15,22 @@ Universal search field component.
   />
 ```
 
+## Usage with ElasticQueryField component
+The component supports adding a boolean value, witch replaces a TextField component with the ElasticQueryField.
+
+```
+  import { SearchField } from '@folio/stripes/components';
+
+  <SearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+
+    isAdvancedSearch={true}
+  />
+```
+
 ## Usage with searchable indexes
 The component supports adding an array of searchable indexes which adds a select field to the component.
 
@@ -55,6 +71,14 @@ loading | boolean | Adds a loading state to icon (on fetch etc.)
 onChange | function | On change handler for the input field
 onClear | function | On clear search field callback
 clearSearchId | string | Adds id to the clear search icon
+
+### With ElasticQueryField component
+Additional props for replacing the TextField component with the ElasticQueryField
+
+Name | type | Description
+-- | -- | --
+isAdvancedSearch | boolean | Replaces the TextField component with the ElasticQueryField
+searchButtonRef | object | Supplies a ref to the search button
 
 ### With searchable indexes
 Additional props for adding searchable indexes/fields.

--- a/src/components/SearchField/stories/BasicUsage.js
+++ b/src/components/SearchField/stories/BasicUsage.js
@@ -1,0 +1,98 @@
+/**
+ * SearchField Usage
+ */
+
+import React, { Component } from 'react';
+import Checkbox from '@folio/stripes-components/lib/Checkbox';
+import SearchField from '../SearchField';
+
+export default class SearchFieldUsage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      value: '',
+      loading: false,
+      selectedIndex: '',
+      hasSearchableIndexes: false,
+    };
+    this.clearValue = this.clearValue.bind(this);
+    this.changeValue = this.changeValue.bind(this);
+    this.changeIndex = this.changeIndex.bind(this);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.asyncFaker);
+  }
+
+  clearValue() {
+    this.setState({
+      value: '',
+    });
+  }
+
+  changeValue(e) {
+    clearInterval(this.asyncFaker);
+
+    this.setState({
+      value: e.target.value,
+      loading: true,
+    });
+
+    this.asyncFaker = setInterval(() => {
+      this.setState({
+        loading: false,
+      });
+    }, 250);
+  }
+
+  changeIndex(e) {
+    this.setState({
+      selectedIndex: e.target.value,
+    });
+  }
+
+  render() {
+    const { hasSearchableIndexes } = this.state;
+    const searchableIndexes = [
+      { label: 'ID', value: 'id' },
+      { label: 'Title', value: 'title', placeholder: 'Please input title...' },
+      { label: 'Identifier', value: 'identifier', localOnly: true },
+      { label: 'ISBN', value: 'identifier/type=isbn' },
+      { label: 'ISSN', value: 'identifier/type=issn' },
+      { label: 'Contributor', value: 'contributor', localOnly: true },
+      { label: 'Subject', value: 'subject', localOnly: true },
+      { label: 'Classification', value: 'classification', localOnly: true },
+      { label: 'Publisher', value: 'publisher' },
+    ];
+
+    return (
+      <div>
+        <Checkbox
+          label="Toggle searchable indexes"
+          id="toggle-searchable-indexes"
+          checked={this.state.hasSearchableIndexes}
+          onChange={() => { this.setState({ hasSearchableIndexes: !hasSearchableIndexes }); }}
+        />
+        <br />
+        <br />
+        <SearchField
+          onClear={this.clearValue}
+          value={this.state.value}
+          loading={this.state.loading}
+          onChange={this.changeValue}
+          placeholder="Enter search term.."
+          aria-label="Search for stuff."
+          clearSearchId="clear-search-button"
+          id="clear-sesrch-field"
+          searchableIndexes={hasSearchableIndexes ? searchableIndexes : null}
+          onChangeIndex={hasSearchableIndexes ? this.changeIndex : null}
+          selectedIndex={hasSearchableIndexes ? this.state.selectedIndex : null}
+          searchableIndexesPlaceholder="Search all.."
+        />
+        <div style={{ marginTop: '1rem', color: '#888' }}>
+          { this.state.value ? `You typed: ${this.state.value}` : 'Try entering a value in the search field.'}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/SearchField/stories/SearchField.stories.js
+++ b/src/components/SearchField/stories/SearchField.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('SearchField', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,3 +12,5 @@ export { default as TitleField } from './TitleField';
 export { default as TitlesView } from './TitlesView';
 export { default as ModalContent } from './ModalContent';
 export { PaneLoading, ViewLoading } from './Loading';
+export { default as SearchAndSort } from './SearchAndSort';
+export { default as SearchField } from './SearchField';

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -96,7 +96,7 @@ export const instanceIndexes = [
   // { label: 'ui-inventory.barcode', value: 'item.barcode', queryTemplate: 'item.barcode=="%{query.query}"' },
   { label: 'ui-inventory.instanceHrid', value: 'hrid', queryTemplate: 'hrid=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
-  { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
+  { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
 ];
 
 export const instanceSortMap = {
@@ -121,7 +121,7 @@ export const holdingIndexes = [
     value: 'callNumberNormalized',
     queryTemplate: 'holdingsRecords.fullCallNumberNormalized="%{query.query}" OR holdingsRecords.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.holdingsHrid', value: 'hrid', queryTemplate: 'holdingsRecords.hrid=="%{query.query}"' },
-  { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
+  { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
 ];
 
 export const holdingSortMap = {};
@@ -168,8 +168,7 @@ export const itemIndexes = [
     value: 'itemCallNumberNorm',
     queryTemplate: 'item.fullCallNumberNormalized="%{query.query}" OR item.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.itemHrid', value: 'hrid', queryTemplate: 'item.hrid=="%{query.query}"' },
-  { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
-
+  { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
 ];
 
 export const itemFilterConfig = [

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -25,7 +25,7 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     queryTemplate = getIsbnIssnTemplate(queryTemplate, identifierTypes, queryIndex);
   }
 
-  if (queryIndex === 'querySearch' && queryValue.match('sortby')) {
+  if (queryIndex === 'advancedSearch' && queryValue.match('sortby')) {
     query.sort = '';
   } else if (!query.sort) {
     // Default sort for filtering/searching instances/holdings/items should be by title (UIIN-1046)
@@ -35,7 +35,7 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
   resourceData.query = { ...query, qindex: '' };
 
   // makeQueryFunction escapes quote and backslash characters by default,
-  // but when submitting a raw CQL query (i.e. when queryIndex === 'querySearch')
+  // but when submitting a raw CQL query (i.e. when queryIndex === 'advancedSearch')
   // we assume the user knows what they are doing and wants to run the CQL as-is.
   return makeQueryFunction(
     CQL_FIND_ALL,
@@ -44,7 +44,7 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     filters,
     2,
     null,
-    queryIndex !== 'querySearch',
+    queryIndex !== 'advancedSearch',
   )(queryParams, pathComponents, resourceData, logger, props);
 }
 

--- a/test/bigtest/tests/holdings-view-page-test.js
+++ b/test/bigtest/tests/holdings-view-page-test.js
@@ -6,7 +6,7 @@ import HoldingsViewPage from '../interactors/holdings-view-page';
 import HoldingsEditPage from '../interactors/holdings-edit-page';
 import HoldingsCreatePage from '../interactors/holdings-create-page';
 
-import translation from '../../../translations/ui-inventory/en';
+import translation from '../../../translations/ui-inventory-es/en';
 
 describe('HoldingsViewPage', () => {
   setupApplication();

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -9,7 +9,7 @@ import ItemViewPage from '../interactors/item-view-page';
 import HoldingsViewPage from '../interactors/holdings-view-page';
 import ItemCreatePage from '../interactors/item-create-page';
 
-import translation from '../../../translations/ui-inventory/en';
+import translation from '../../../translations/ui-inventory-es/en';
 
 const headersMap = {
   BARCODE: InstanceViewPage.itemsList.headers(0),

--- a/test/bigtest/tests/settings/fast-add/fast-add-test.js
+++ b/test/bigtest/tests/settings/fast-add/fast-add-test.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 
 import setupApplication from '../../../helpers/setup-application';
 import FastAddSettings from '../../../interactors/settings/fast-add/fast-add';
-import translation from '../../../../../translations/ui-inventory/en';
+import translation from '../../../../../translations/ui-inventory-es/en';
 
 describe('Settings page for Fast add', () => {
   setupApplication();

--- a/test/bigtest/tests/settings/hrid-handling/hrid-handling-test.js
+++ b/test/bigtest/tests/settings/hrid-handling/hrid-handling-test.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 
 import setupApplication from '../../../helpers/setup-application';
 import HRIDHandlingInteractor from '../../../interactors/settings/hrid-handling/hrid-handling';
-import translation from '../../../../../translations/ui-inventory/en';
+import translation from '../../../../../translations/ui-inventory-es/en';
 
 const START_WITH_MAX_LENGTH = 11;
 const ASSIGN_PREFIX_MAX_LENGTH = 10;

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 
-import translations from '../../../translations/ui-inventory/en';
+import translations from '../../../translations/ui-inventory-es/en';
 import prefixKeys from './prefixKeys';
 import mockOffsetSize from './mockOffsetSize';
 

--- a/test/jest/helpers/translationsProperties.js
+++ b/test/jest/helpers/translationsProperties.js
@@ -1,7 +1,7 @@
 import stripesComponentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
 import stripesSmartComponentsTranslations from '@folio/stripes-smart-components/translations/stripes-smart-components/en';
 
-import translations from '../../../translations/ui-inventory/en';
+import translations from '../../../translations/ui-inventory-es/en';
 
 const translationsProperties = [
   {

--- a/translations/ui-inventory-es/en.json
+++ b/translations/ui-inventory-es/en.json
@@ -280,7 +280,7 @@
   "addSeries": "Add series",
   "subjects": "Subjects",
   "subject": "Subject",
-  "querySearch": "Query search",
+  "advancedSearch": "Advanced search",
   "addSubject": "Add subject",
   "url": "URL",
   "urls": "URLs",

--- a/translations/ui-inventory-es/en_US.json
+++ b/translations/ui-inventory-es/en_US.json
@@ -411,7 +411,7 @@
     "item.status.missing": "Missing",
     "item.status.onOrder": "On order",
     "item.status.paged": "Paged",
-    "querySearch": "Query search",
+    "advancedSearch": "Advanced search",
     "holdings.permanentLocation": "Holdings permanent location",
     "inTransitReport": "In transit items report (CSV)",
     "reports.inTransitItem.barcode": "Item barcode",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77053927/107752426-63c5ed80-6d27-11eb-905d-3186925d09db.png)

PR for the [sub-task](https://issues.folio.org/browse/UISEES-37).

The purpose is to replace the `Query search` mode with an `Advanced search`. When the user selects `Advanced search` mode a new `ElasticQueryField` component appears.

For this, I need to work with a `SearchAndSort` stripes-smart-component and a `SearchField` stripes-component. To only work in an ui-inventory-es module (POC) I copied these components into the module.
I created new a `ElasticQueryField` component ([on initial stage](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-81765dee44697d24c12cf957c862f8e88da01712a678edc61341ec2b218c499e)), added `isAdvancedSearch` and `searchButtonRef` props to the `SearhcField` component ([lines](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-2f4083a1a4881b81a75ed2c72be2c7f1dd797713ad3c0c4854823dfbf6269e5c) 1020, 1025), expanded the `SearchField` component with the `ElasticQueryField` component ([lines](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-2f4083a1a4881b81a75ed2c72be2c7f1dd797713ad3c0c4854823dfbf6269e5c) 114 - 140), added the description to a [storybook](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-29424a9479063ba66151a6be35ef4fab1c942c26ca9a69bbdd8060383c3314ce), renamed `Query Search` to `Advanced search` ([1](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-29424a9479063ba66151a6be35ef4fab1c942c26ca9a69bbdd8060383c3314ce), [2](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-03423e533e7101fe103a71bd392486b92db5623a15d76ce0bbd3a96c39668017), [3](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-31a9388ff2727472991ede393aeda2a3e3aa338f12e3ca8533f523973852223a), [4](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-fe3175200f90ffae7775f7577709846f57016b2e56c29a52c6821a2000fd47d3), [5](https://github.com/folio-org/ui-inventory-es/pull/2/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md#diff-df86c409be71a694cc9b8d7354838283f18c66b82ab9714c5a8ec19676619bc9)).