### PR TITLE
UISEES-34: Add the supported search options

### DIFF
--- a/src/components/ElasticQueryField/ElasticQueryField.css
+++ b/src/components/ElasticQueryField/ElasticQueryField.css
@@ -1,0 +1,14 @@
+.multiSelectSearchWrapper {
+  position: relative;
+}
+
+.optionMenu {
+  position: absolute;
+  width: 100%;
+  composes: multiSelectMenu from '../../../../stripes-components/lib/MultiSelection/MultiSelect.css';
+}
+
+.optionList {
+  max-height: 168px;
+  composes: multiSelectOptionList from '../../../../stripes-components/lib/MultiSelection/MultiSelect.css';
+}

--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import TextArea from '@folio/stripes-components/lib/TextArea';
+import ListItem from './ListItem';
+import css from './ElasticQueryField.css';
 
+const UNSELECTED_SUGGESTION_INDEX = -1;
 const defaultStyle = {
   height: '20px',
   resize: 'none',
@@ -10,6 +13,10 @@ const defaultStyle = {
 const propTypes = {
   onChange: PropTypes.func,
   searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  searchOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+  })),
   style: PropTypes.object,
   value: PropTypes.string,
 };
@@ -18,15 +25,28 @@ const ElasticQueryField = props => {
   const {
     onChange,
     searchButtonRef = {},
+    searchOptions,
     style = defaultStyle,
     value = '',
   } = props;
+
+  const [searchOption, setSearchOption] = useState('');
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(UNSELECTED_SUGGESTION_INDEX);
+  const [isArrowUp, setIsArrowUp] = useState(false);
 
   const handleSearchTermsChange = event => {
     onChange(event);
   };
 
+  const getSuggestions = () => {
+    if (!searchOption) return searchOptions;
+    return [];
+  };
+
   const handleKeyDown = event => {
+    const suggestions = getSuggestions();
+    const lastSuggestionIndex = suggestions.length - 1;
+
     switch (event.keyCode) {
       case 13: // enter
         event.preventDefault();
@@ -34,18 +54,64 @@ const ElasticQueryField = props => {
           searchButtonRef.current.click();
         }
         break;
+      case 40: // arrowDown
+        if (suggestions.length) {
+          const isLastSuggestion = selectedSuggestionIndex === lastSuggestionIndex;
+          setIsArrowUp(false);
+          if (isLastSuggestion) {
+            setSelectedSuggestionIndex(0);
+          } else {
+            setSelectedSuggestionIndex(prevState => prevState + 1);
+          }
+        }
+        break;
+      case 38: // arrowUp
+        if (suggestions.length) {
+          const isFirstSuggestion = !selectedSuggestionIndex;
+          setIsArrowUp(true);
+          if (isFirstSuggestion) {
+            setSelectedSuggestionIndex(lastSuggestionIndex);
+          } else {
+            setSelectedSuggestionIndex(prevState => prevState - 1);
+          }
+        }
+        break;
       default:
     }
   };
 
+  const renderDropDown = () => {
+    const suggestions = getSuggestions();
+
+    return (
+      !suggestions?.length ? null : (
+        <div className={css.optionMenu}>
+          <ul className={css.optionList}>
+            {suggestions.map(({ label }, index) => (
+              <ListItem
+                key={label}
+                value={label}
+                isSelected={selectedSuggestionIndex === index}
+                isArrowUp={isArrowUp}
+              />
+            ))}
+          </ul>
+        </div>
+      )
+    );
+  };
+
   return (
-    <TextArea
-      style={style}
-      marginBottom0
-      value={value}
-      onChange={handleSearchTermsChange}
-      onKeyDown={handleKeyDown}
-    />
+    <div className={css.multiSelectSearchWrapper}>
+      <TextArea
+        style={style}
+        marginBottom0
+        value={value}
+        onChange={handleSearchTermsChange}
+        onKeyDown={handleKeyDown}
+      />
+      {value && renderDropDown()}
+    </div>
   );
 };
 

--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -80,19 +80,19 @@ const ElasticQueryField = props => {
     return (
       suggestions?.length
         ? (
-            <div className={css.optionMenu}>
-              <ul className={css.optionList}>
-                {suggestions.map(({ label }, index) => (
-                  <ListItem
-                    key={label}
-                    value={label}
-                    isSelected={selectedSuggestionIndex === index}
-                    isArrowUp={isArrowUp}
-                  />
-                ))}
-              </ul>
-            </div>
-          )
+          <div className={css.optionMenu}>
+            <ul className={css.optionList}>
+              {suggestions.map(({ label }, index) => (
+                <ListItem
+                  key={label}
+                  value={label}
+                  isSelected={selectedSuggestionIndex === index}
+                  isArrowUp={isArrowUp}
+                />
+              ))}
+            </ul>
+          </div>
+        )
         : null
     );
   };

--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -5,10 +5,6 @@ import ListItem from './ListItem';
 import css from './ElasticQueryField.css';
 
 const UNSELECTED_SUGGESTION_INDEX = -1;
-const defaultStyle = {
-  height: '20px',
-  resize: 'none',
-};
 
 const propTypes = {
   onChange: PropTypes.func,
@@ -17,7 +13,6 @@ const propTypes = {
     label: PropTypes.string,
     value: PropTypes.string,
   })),
-  style: PropTypes.object,
   value: PropTypes.string,
 };
 
@@ -26,7 +21,6 @@ const ElasticQueryField = props => {
     onChange,
     searchButtonRef = {},
     searchOptions,
-    style = defaultStyle,
     value = '',
   } = props;
 
@@ -104,7 +98,6 @@ const ElasticQueryField = props => {
   return (
     <div className={css.multiSelectSearchWrapper}>
       <TextArea
-        style={style}
         marginBottom0
         value={value}
         onChange={handleSearchTermsChange}

--- a/src/components/ElasticQueryField/ListItem/ListItem.css
+++ b/src/components/ElasticQueryField/ListItem/ListItem.css
@@ -1,0 +1,11 @@
+.option {
+  composes: option from '../../../../../stripes-components/lib/Selection/Selection.css';
+
+&:hover {
+   box-shadow: inset 0 0 0 3px var(--primary);
+ }
+}
+
+.optionCursor {
+  composes: optionCursor from '../../../../../stripes-components/lib/MultiSelection/MultiSelect.css';
+}

--- a/src/components/ElasticQueryField/ListItem/ListItem.js
+++ b/src/components/ElasticQueryField/ListItem/ListItem.js
@@ -1,0 +1,32 @@
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import css from './ListItem.css';
+
+const propTypes = {
+  isArrowUp: PropTypes.bool,
+  isSelected: PropTypes.bool,
+  value: PropTypes.string,
+};
+
+const ListItem = ({ value, isSelected, isArrowUp }) => {
+  const optionRef = useRef(null);
+
+  if (isSelected && optionRef.current) {
+    optionRef.current.scrollIntoView(isArrowUp);
+    optionRef.current.focus();
+  }
+
+  return (
+    <li
+      ref={optionRef}
+      className={classNames(css.option, isSelected && css.optionCursor)}
+    >
+      {value}
+    </li>
+  );
+};
+
+ListItem.propTypes = propTypes;
+
+export default ListItem;

--- a/src/components/ElasticQueryField/ListItem/index.js
+++ b/src/components/ElasticQueryField/ListItem/index.js
@@ -1,0 +1,1 @@
+export { default } from './ListItem';

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -88,6 +88,7 @@ class InstancesList extends React.Component {
     }).isRequired,
     renderFilters: PropTypes.func.isRequired,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object).isRequired,
+    searchableIndexesES: PropTypes.arrayOf(PropTypes.object).isRequired,
   };
 
   static contextType = CalloutContext;
@@ -459,6 +460,7 @@ class InstancesList extends React.Component {
       parentMutator,
       renderFilters,
       searchableIndexes,
+      searchableIndexesES,
       match: {
         path,
       }
@@ -526,6 +528,12 @@ class InstancesList extends React.Component {
       return { ...index, label };
     });
 
+    const formattedSearchableIndexesES = searchableIndexesES.map(index => {
+      const label = intl.formatMessage({ id: index.label });
+
+      return { ...index, label };
+    });
+
     return (
       <>
         <div data-test-inventory-instances>
@@ -536,6 +544,7 @@ class InstancesList extends React.Component {
             maxSortKeys={1}
             renderNavigation={this.renderNavigation}
             searchableIndexes={formattedSearchableIndexes}
+            searchableIndexesES={formattedSearchableIndexesES}
             selectedIndex={get(data.query, 'qindex')}
             searchableIndexesPlaceholder={null}
             initialResultCount={INITIAL_RESULT_COUNT}

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -199,6 +199,7 @@ class SearchAndSort extends React.Component {
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
     resultsFormatter: PropTypes.shape({}),
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
+    searchableIndexesES: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
@@ -993,6 +994,7 @@ class SearchAndSort extends React.Component {
       renderNavigation,
       disableFilters,
       searchableIndexes,
+      searchableIndexesES,
       selectedIndex,
     } = this.props;
     const {
@@ -1022,6 +1024,7 @@ class SearchAndSort extends React.Component {
               ariaLabel={ariaLabel}
               className={css.searchField}
               searchableIndexes={searchableIndexes}
+              searchableIndexesES={searchableIndexesES}
               searchButtonRef={this.searchButtonRef}
               selectedIndex={queryIndex}
               value={searchTerm}

--- a/src/components/SearchField/SearchField.js
+++ b/src/components/SearchField/SearchField.js
@@ -38,6 +38,10 @@ const propTypes = {
     placeholder: PropTypes.string,
     value: PropTypes.string,
   })),
+  searchableIndexesES: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+  })),
   searchableIndexesPlaceholder: PropTypes.string,
   searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   selectedIndex: PropTypes.string,
@@ -56,6 +60,7 @@ const SearchField = (props) => {
     loading,
     clearSearchId,
     searchableIndexes,
+    searchableIndexesES,
     onChangeIndex,
     selectedIndex,
     searchableIndexesPlaceholder,
@@ -116,6 +121,7 @@ const SearchField = (props) => {
           <ElasticQueryField
             onChange={onChange}
             searchButtonRef={searchButtonRef}
+            searchOptions={searchableIndexesES}
             value={value}
           />
         )

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -99,6 +99,18 @@ export const instanceIndexes = [
   { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
 ];
 
+export const instanceIndexesES = [
+  { label: 'Keyword (title, contributor, identifier)', value: 'Keyword' },
+  { label: 'Title (all)', value: 'Title' },
+  { label: 'Contributors', value: 'Contributors' },
+  { label: 'Identifiers (all)', value: 'Identifier' },
+  { label: 'ISSN', value: 'ISSN' },
+  { label: 'ISBN', value: 'ISBN' },
+  { label: 'Subject', value: 'Subject' },
+  { label: 'Instance UUID', value: 'UUID' },
+  { label: 'Instance HRID', value: 'HRID' },
+];
+
 export const instanceSortMap = {
   Title: 'title',
   publishers: 'publication',
@@ -122,6 +134,14 @@ export const holdingIndexes = [
     queryTemplate: 'holdingsRecords.fullCallNumberNormalized="%{query.query}" OR holdingsRecords.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.holdingsHrid', value: 'hrid', queryTemplate: 'holdingsRecords.hrid=="%{query.query}"' },
   { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
+];
+
+export const holdingIndexesES = [
+  { label: 'Keyword (title, contributor, identifier)', value: 'Keyword' },
+  { label: 'ISSN', value: 'ISSN' },
+  { label: 'ISBN', value: 'ISBN' },
+  { label: 'Call Number', value: 'Call Number' },
+  { label: 'Holdings HRID', value: 'HRID' },
 ];
 
 export const holdingSortMap = {};
@@ -169,6 +189,15 @@ export const itemIndexes = [
     queryTemplate: 'item.fullCallNumberNormalized="%{query.query}" OR item.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.itemHrid', value: 'hrid', queryTemplate: 'item.hrid=="%{query.query}"' },
   { label: 'ui-inventory-es.advancedSearch', value: 'advancedSearch', queryTemplate: '%{query.query}' },
+];
+
+export const itemIndexesES = [
+  { label: 'Keyword (title, contributor, identifier)', value: 'Keyword' },
+  { label: 'Barcode', value: 'Barcode' },
+  { label: 'ISSN', value: 'ISSN' },
+  { label: 'ISBN', value: 'ISBN' },
+  { label: 'Call Number', value: 'Call Number' },
+  { label: 'Item HRID', value: 'Item HRID' },
 ];
 
 export const itemFilterConfig = [
@@ -234,4 +263,17 @@ const config = {
   }
 };
 
+const configES = {
+  instances: {
+    indexesES: instanceIndexesES,
+  },
+  holdings: {
+    indexesES: holdingIndexesES,
+  },
+  items: {
+    indexesES: itemIndexesES,
+  },
+};
+
 export const getFilterConfig = (segment = 'instances') => config[segment];
+export const getFilterConfigES = (segment = 'instances') => configES[segment];

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -8,6 +8,7 @@ import withLocation from '../withLocation';
 import { InstancesView } from '../views';
 import {
   getFilterConfig,
+  getFilterConfigES,
 } from '../filterConfig';
 import { buildManifestObject } from './buildManifestObject';
 import { DataContext } from '../contexts';
@@ -43,6 +44,7 @@ class InstancesRoute extends React.Component {
     } = this.props;
     const { segment } = getParams(this.props);
     const { indexes, renderer } = getFilterConfig(segment);
+    const { indexesES } = getFilterConfigES(segment);
     const { query } = resources;
 
     return (
@@ -59,6 +61,7 @@ class InstancesRoute extends React.Component {
             renderFilters={renderer({ ...data, query })}
             segment={segment}
             searchableIndexes={indexes}
+            searchableIndexesES={indexesES}
           />
         )}
       </DataContext.Consumer>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/77053927/107766619-63841d00-6d3c-11eb-8a4b-62dc8643db30.png) 
![image](https://user-images.githubusercontent.com/77053927/107766697-844c7280-6d3c-11eb-9f80-024fb9ec2820.png) 
![image](https://user-images.githubusercontent.com/77053927/107766759-9fb77d80-6d3c-11eb-8c38-65e2a6e2a559.png)

PR for the [sub-task](https://issues.folio.org/browse/UISEES-34).

The purpose is to show the appropriate suggestions, depending on the selected tab (Instance, Holdings, Item), when a user starts entering text in the `Advanced search` field.

I created the [suggestions](https://github.com/folio-org/ui-inventory-es/pull/3/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json#diff-03423e533e7101fe103a71bd392486b92db5623a15d76ce0bbd3a96c39668017) and passed them to the `ElasticQueryField` component, expanded its functionality to display them ([1](https://github.com/folio-org/ui-inventory-es/pull/3/files?file-filters%5B%5D=.css&file-filters%5B%5D=.js#diff-81765dee44697d24c12cf957c862f8e88da01712a678edc61341ec2b218c499e), [2](https://github.com/folio-org/ui-inventory-es/pull/3/files?file-filters%5B%5D=.css&file-filters%5B%5D=.js#diff-7f41f02e812fa7f1fbaa7e2881b5392ebe0c2f5a2098d9c06be55404098af545), [3](https://github.com/folio-org/ui-inventory-es/pull/3/files?file-filters%5B%5D=.css&file-filters%5B%5D=.js#diff-1d337fa1f439a5de1325cf49847a7e0836cf3c79d8200145c328b9c5106c2dd3), [4](https://github.com/folio-org/ui-inventory-es/pull/3/files?file-filters%5B%5D=.css&file-filters%5B%5D=.js#diff-56c24af2677c06021c818c590422041d3de48886e392ea0ca113844ddc5ed947)).