### PR TITLE
UISEES-43: Bump data-export interface version

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",
-      "data-export": "3.0"
+      "data-export": "4.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
In the scope of [UISEES-43](https://issues.folio.org/browse/UISEES-43)

## Purpose
Bump the `data-export` interface dependency to v4.0, since the latest `mod-data-export` release included interface bump, that's now causing build failure of reference envs. 
See [FOLIO-3075](https://issues.folio.org/browse/FOLIO-3075) for more details.

