### PR TITLE
UISEES-31: Update filters options for Items with the facet data

### DIFF
--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -19,7 +19,7 @@ import {
 import {
   FACETS,
   FACETS_OPTIONS,
-  IDs,
+  FACETS_CQL,
   FACETS_SETTINGS,
 } from '../../constants';
 
@@ -62,14 +62,14 @@ const HoldingsRecordFilters = (props) => {
         const commonProps = [recordValues, accum, name];
 
         switch (recordName) {
-          case IDs.EFFECTIVE_LOCATION_ID:
-          case IDs.HOLDINGS_PERMANENT_LOCATION_ID:
+          case FACETS_CQL.EFFECTIVE_LOCATION:
+          case FACETS_CQL.HOLDINGS_PERMANENT_LOCATION:
             processFacetOptions(locations, ...commonProps);
             break;
-          case IDs.HOLDINGS_DISCOVERY_SUPPRESS_ID:
+          case FACETS_CQL.HOLDINGS_DISCOVERY_SUPPRESS:
             accum[name] = getSuppressedOptions(recordValues);
             break;
-          case IDs.HOLDINGS_TAGS_ID:
+          case FACETS_CQL.HOLDINGS_TAGS:
             processFacetOptions(tagsRecords, ...commonProps);
             break;
           default:


### PR DESCRIPTION
[UISEES-31](https://issues.folio.org/browse/UISEES-31): Update filters options for Items with the facet data

## Purpose

- change the name of the constants for CQL