### PR TITLE
UISEES-46: Set the default order on the results pane to order by ranking

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "displayName": "ui-inventory-es.meta.title",
     "route": "/search",
-    "home": "/search?filters=&sort=title",
+    "home": "/search?filters=",
     "queryResource": "query",
     "icons": [
       {

--- a/src/components/FilterNavigation/FilterNavigation.js
+++ b/src/components/FilterNavigation/FilterNavigation.js
@@ -17,7 +17,7 @@ const FilterNavigation = ({ segment }) => (
       Object.keys(segments).map(name => (
         <Button
           key={`${name}`}
-          to={`/search?segment=${name}&sort=title`}
+          to={`/search?segment=${name}`}
           buttonStyle={`${segment === name ? 'primary' : 'default'}`}
           id={`segment-navigation-${name}`}
         >

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -27,9 +27,6 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
 
   if (queryIndex === 'advancedSearch' && queryValue.match('sortby')) {
     query.sort = '';
-  } else if (!query.sort) {
-    // Default sort for filtering/searching instances/holdings/items should be by title (UIIN-1046)
-    query.sort = 'title';
   }
 
   resourceData.query = { ...query, qindex: '' };
@@ -37,7 +34,7 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
   // makeQueryFunction escapes quote and backslash characters by default,
   // but when submitting a raw CQL query (i.e. when queryIndex === 'advancedSearch')
   // we assume the user knows what they are doing and wants to run the CQL as-is.
-  return makeQueryFunction(
+  const cql = makeQueryFunction(
     CQL_FIND_ALL,
     queryTemplate,
     sortMap,
@@ -46,6 +43,10 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     null,
     queryIndex !== 'advancedSearch',
   )(queryParams, pathComponents, resourceData, logger, props);
+
+  return cql === undefined
+    ? CQL_FIND_ALL
+    : cql;
 }
 
 export function buildManifestObject() {
@@ -55,7 +56,7 @@ export function buildManifestObject() {
       initialValue: {
         query: '',
         filters: '',
-        sort: 'title',
+        sort: '',
       },
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },


### PR DESCRIPTION
[UISEES-46](https://issues.folio.org/browse/UISEES-46): Set the default order on the results pane to order by ranking

## Purpose
remove search by 'title' as a default