### PR TITLE
UISEES-49: Expand search options - electronic access for instances, holdings and items

### DIFF
--- a/src/components/ElasticQueryField/ElasticQueryField.js
+++ b/src/components/ElasticQueryField/ElasticQueryField.js
@@ -10,6 +10,7 @@ const UNSELECTED_OPTION_INDEX = -1;
 const SPACE = ' ';
 const OPEN_BRACKET = '(';
 const CLOSE_BRACKET = ')';
+const SLASH = '/';
 
 const propTypes = {
   booleanOperators: PropTypes.arrayOf(PropTypes.shape({
@@ -94,10 +95,19 @@ const ElasticQueryField = props => {
     }
 
     if (valueToInsert.startsWith(OPEN_BRACKET)) {
+      if (valueToInsert.includes(SLASH)) {
+        return `${OPEN_BRACKET}"${valueToInsert.slice(1)}"`;
+      }
       return `${OPEN_BRACKET}${valueToInsert.slice(1)}`;
     }
     if (valueToInsert.endsWith(CLOSE_BRACKET)) {
+      if (valueToInsert.includes(SLASH)) {
+        return `"${valueToInsert.slice(0, -1)}"${CLOSE_BRACKET}`;
+      }
       return `${valueToInsert.slice(0, -1)}${CLOSE_BRACKET}`;
+    }
+    if (valueToInsert.includes(SLASH)) {
+      return `"${valueToInsert}"`;
     }
     return `${valueToInsert}`;
   };

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -111,6 +111,11 @@ export const instanceIndexesES = [
   { label: 'ui-inventory-es.subject', value: 'Subject', queryTemplate: 'subjects all' },
   { label: 'ui-inventory-es.instanceId', value: 'UUID', queryTemplate: 'id==' },
   { label: 'ui-inventory-es.instanceHrid', value: 'HRID', queryTemplate: 'hrid==' },
+  { label: 'ui-inventory-es.electronicAccessAll', value: 'Electronic access (all)', queryTemplate: 'electronicAccess==' },
+  { label: 'ui-inventory-es.electronicAccessURI', value: 'Electronic access (URI)', queryTemplate: 'electronicAccess.uri==' },
+  { label: 'ui-inventory-es.electronicAccessPublicNote', value: 'Electronic access (Public Note)', queryTemplate: 'electronicAccess.publicNote all' },
+  { label: 'ui-inventory-es.electronicAccessLinkText', value: 'Electronic access (Link text)', queryTemplate: 'electronicAccess.linkText all' },
+  { label: 'ui-inventory-es.electronicAccessMaterialsSpecified', value: 'Electronic access (Materials specified)', queryTemplate: 'electronicAccess.materialsSpecification all' },
 ];
 
 export const instanceSortMap = {
@@ -144,6 +149,11 @@ export const holdingIndexesES = [
   { label: 'ui-inventory-es.isbn', value: 'ISBN', queryTemplate: 'isbn==' },
   { label: 'ui-inventory-es.callNumber', value: 'Call Number', queryTemplate: 'holdings.fullCallNumber==' },
   { label: 'ui-inventory-es.holdingsHrid', value: 'HRID', queryTemplate: 'holdings.hrid==' },
+  { label: 'ui-inventory-es.electronicAccessAll', value: 'Electronic access (all)', queryTemplate: 'electronicAccess==' },
+  { label: 'ui-inventory-es.electronicAccessURI', value: 'Electronic access (URI)', queryTemplate: 'electronicAccess.uri==' },
+  { label: 'ui-inventory-es.electronicAccessPublicNote', value: 'Electronic access (Public Note)', queryTemplate: 'electronicAccess.publicNote all' },
+  { label: 'ui-inventory-es.electronicAccessLinkText', value: 'Electronic access (Link text)', queryTemplate: 'electronicAccess.linkText all' },
+  { label: 'ui-inventory-es.electronicAccessMaterialsSpecified', value: 'Electronic access (Materials specified)', queryTemplate: 'electronicAccess.materialsSpecification all' },
 ];
 
 export const holdingSortMap = {};
@@ -199,6 +209,11 @@ export const itemIndexesES = [
   { label: 'ui-inventory-es.isbn', value: 'ISBN', queryTemplate: 'isbn==' },
   { label: 'ui-inventory-es.callNumber', value: 'Call Number', queryTemplate: 'items.effectiveCallNumberComponents==' },
   { label: 'ui-inventory-es.itemHrid', value: 'Item HRID', queryTemplate: 'items.hrid==' },
+  { label: 'ui-inventory-es.electronicAccessAll', value: 'Electronic access (all)', queryTemplate: 'electronicAccess==' },
+  { label: 'ui-inventory-es.electronicAccessURI', value: 'Electronic access (URI)', queryTemplate: 'electronicAccess.uri==' },
+  { label: 'ui-inventory-es.electronicAccessPublicNote', value: 'Electronic access (Public Note)', queryTemplate: 'electronicAccess.publicNote all' },
+  { label: 'ui-inventory-es.electronicAccessLinkText', value: 'Electronic access (Link text)', queryTemplate: 'electronicAccess.linkText all' },
+  { label: 'ui-inventory-es.electronicAccessMaterialsSpecified', value: 'Electronic access (Materials specified)', queryTemplate: 'electronicAccess.materialsSpecification all' },
 ];
 
 export const itemFilterConfig = [

--- a/translations/ui-inventory-es/en.json
+++ b/translations/ui-inventory-es/en.json
@@ -592,5 +592,10 @@
   "parser.invalidSearchClause": "Invalid search clause",
   "parser.missingCloseParenthesis": "Missing closing parenthesis",
   "parser.strOrQuotedExpression": "Expecting string or a quoted expression",
-  "POC": "Proof of concept"
+  "POC": "Proof of concept",
+  "electronicAccessAll": "Electronic access all fields",
+  "electronicAccessURI": "Electronic access - URI",
+  "electronicAccessPublicNote": "Electronic access - Public note",
+  "electronicAccessLinkText": "Electronic access - Link Text",
+  "electronicAccessMaterialsSpecified": "Electronic access - Materials Specified"
 }

--- a/translations/ui-inventory-es/en_US.json
+++ b/translations/ui-inventory-es/en_US.json
@@ -592,5 +592,10 @@
     "parser.invalidSearchClause": "Invalid search clause",
     "parser.missingCloseParenthesis": "Missing closing parenthesis",
     "parser.strOrQuotedExpression": "Expecting string or a quoted expression",
-    "POC": "Proof of concept"
+    "POC": "Proof of concept",
+    "electronicAccessAll": "Electronic access all fields",
+    "electronicAccessURI": "Electronic access - URI",
+    "electronicAccessPublicNote": "Electronic access - Public note",
+    "electronicAccessLinkText": "Electronic access - Link Text",
+    "electronicAccessMaterialsSpecified": "Electronic access - Materials Specified"
 }


### PR DESCRIPTION
[UISEES-49](https://issues.folio.org/browse/UISEES-49): Expand search options - electronic access for instances, holdings and items

## Purpose
add 'electronic access' options to advanced search for instances, holdings and items

- add electronic access search option
- add quotes to search term if it contains '/'