### PR TITLE
UISEES-65: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-inventory
 
+## (IN PROGRESS)
+* Also support `circulation` `11.0`. Refs UISEES-65.
+
 ## [6.3.0](https://github.com/folio-org/ui-inventory-es/tree/v6.3.0) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-inventory-es/compare/v6.2.0...v6.3.0)
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       "holdings-sources": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "10.0",
+      "circulation": "10.0 11.0",
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UISEES-65